### PR TITLE
feat: add S3 upload presign route

### DIFF
--- a/apps/server/app/api/routes/uploads.py
+++ b/apps/server/app/api/routes/uploads.py
@@ -1,0 +1,41 @@
+import uuid
+
+import boto3
+from fastapi import APIRouter, Depends
+from fastapi.responses import JSONResponse
+
+from app.core.config import settings
+from app.core.security import get_current_user
+
+router = APIRouter(
+    prefix="/uploads",
+    tags=["uploads"],
+    dependencies=[Depends(get_current_user)],
+)
+
+
+def _s3_client():
+    return boto3.client(
+        "s3",
+        endpoint_url=settings.s3_endpoint_url,
+        region_name=settings.s3_region,
+        aws_access_key_id=settings.s3_access_key,
+        aws_secret_access_key=settings.s3_secret_key,
+    )
+
+
+@router.post("/presign")
+def presign_upload():
+    client = _s3_client()
+    key = str(uuid.uuid4())
+    presigned = client.generate_presigned_post(
+        Bucket=settings.s3_bucket,
+        Key=key,
+        ExpiresIn=settings.s3_presign_ttl,
+    )
+    data = {
+        "url": presigned["url"],
+        "fields": presigned["fields"],
+        "expires_in": settings.s3_presign_ttl,
+    }
+    return JSONResponse(data, headers={"Access-Control-Allow-Origin": settings.s3_cors_origin})

--- a/apps/server/app/core/config.py
+++ b/apps/server/app/core/config.py
@@ -12,6 +12,15 @@ class Settings(BaseSettings):
     # For development, default to plain 'admin'. Provide a bcrypt hash via env for production.
     admin_password_hash: str = "admin"
 
+    # Hetzner S3 configuration
+    s3_endpoint_url: str = "https://example.com"
+    s3_region: str = "us-east-1"
+    s3_bucket: str = "dokusuite"
+    s3_access_key: str = "test"
+    s3_secret_key: str = "test"
+    s3_presign_ttl: int = 3600  # seconds
+    s3_cors_origin: str = "*"
+
     # Pydantic v2 style config
     model_config = SettingsConfigDict(env_prefix="DOKUSUITE_")
 

--- a/apps/server/app/main.py
+++ b/apps/server/app/main.py
@@ -6,6 +6,7 @@ from .api.routes import health as health_routes
 from .api.routes import locations as location_routes
 from .api.routes import orders as order_routes
 from .api.routes import photos as photo_routes
+from .api.routes import uploads as upload_routes
 from .core.config import settings
 
 
@@ -17,6 +18,7 @@ def create_app() -> FastAPI:
     app.include_router(photo_routes.router)
     app.include_router(order_routes.router)
     app.include_router(export_routes.router)
+    app.include_router(upload_routes.router)
     return app
 
 

--- a/apps/server/pyproject.toml
+++ b/apps/server/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
   "email-validator>=2.1",
   "sqlmodel>=0.0.22",
   "alembic>=1.13",
+  "boto3>=1.34",
 ]
 
 [project.optional-dependencies]

--- a/apps/server/tests/test_uploads.py
+++ b/apps/server/tests/test_uploads.py
@@ -1,0 +1,24 @@
+from fastapi.testclient import TestClient
+
+from app.core.config import settings
+from app.core.security import create_access_token
+from app.main import create_app
+
+client = TestClient(create_app())
+
+
+def auth_headers():
+    token = create_access_token(settings.admin_email, settings.access_token_expires_minutes)[
+        "access_token"
+    ]
+    return {"Authorization": f"Bearer {token}"}
+
+
+def test_presign_generates_url_and_expiry():
+    r = client.post("/uploads/presign", headers=auth_headers())
+    assert r.status_code == 200
+    data = r.json()
+    expected_url = f"{settings.s3_endpoint_url}/{settings.s3_bucket}"
+    assert data["url"] == expected_url
+    assert data["expires_in"] == settings.s3_presign_ttl
+    assert "key" in data["fields"]


### PR DESCRIPTION
## Summary
- add S3 upload presign route for Hetzner object storage
- configure S3 client (bucket, TTL, CORS)
- add tests for presign URL and expiry

## Testing
- `ruff check app/core/config.py app/api/routes/uploads.py app/main.py tests/test_uploads.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_689b130af828832b9828066d176d00c9