### PR TITLE
feat(server): normalize image orientation

### DIFF
--- a/apps/server/app/api/routes/photos.py
+++ b/apps/server/app/api/routes/photos.py
@@ -1,7 +1,8 @@
-from fastapi import APIRouter, Depends, status
-from fastapi.responses import JSONResponse
+from fastapi import APIRouter, Depends, File, UploadFile, status
+from fastapi.responses import JSONResponse, Response
 
 from app.core.security import get_current_user
+from app.services.exif import normalize_orientation
 
 router = APIRouter(prefix="/photos", tags=["photos"], dependencies=[Depends(get_current_user)])
 
@@ -17,8 +18,10 @@ def list_photos():
 
 
 @router.post("")
-def ingest_photo():
-    return JSONResponse({"status": "not_implemented"}, status_code=status.HTTP_501_NOT_IMPLEMENTED)
+async def ingest_photo(file: UploadFile = File(...)):
+    data = await file.read()
+    normalized = normalize_orientation(data)
+    return Response(content=normalized, media_type=file.content_type)
 
 
 @router.get("/{photo_id}")

--- a/apps/server/app/services/exif.py
+++ b/apps/server/app/services/exif.py
@@ -1,0 +1,23 @@
+from io import BytesIO
+
+from PIL import ExifTags, Image, ImageOps
+
+# EXIF tag for orientation
+ORIENTATION_TAG = next((k for k, v in ExifTags.TAGS.items() if v == "Orientation"), None)
+
+
+def get_orientation(image: Image.Image) -> int | None:
+    """Return the EXIF orientation value if present."""
+    if ORIENTATION_TAG is None:
+        return None
+    exif = image.getexif()
+    return exif.get(ORIENTATION_TAG)
+
+
+def normalize_orientation(data: bytes) -> bytes:
+    """Return image bytes with EXIF orientation applied."""
+    with Image.open(BytesIO(data)) as image:
+        corrected = ImageOps.exif_transpose(image)
+        output = BytesIO()
+        corrected.save(output, format=image.format)
+        return output.getvalue()

--- a/apps/server/pyproject.toml
+++ b/apps/server/pyproject.toml
@@ -20,6 +20,8 @@ dependencies = [
   "boto3>=1.34",
   "redis>=6.4",
   "rq>=2.4",
+  "Pillow>=10.0",
+  "python-multipart>=0.0.6",
 ]
 
 [project.optional-dependencies]

--- a/apps/server/tests/test_exif.py
+++ b/apps/server/tests/test_exif.py
@@ -1,0 +1,28 @@
+from io import BytesIO
+
+from PIL import Image
+
+from app.services.exif import get_orientation, normalize_orientation
+
+
+def _make_orientation_6_image() -> bytes:
+    """Return JPEG bytes with EXIF orientation set to 6 (90° CW)."""
+    img = Image.new("RGB", (1, 2), color="red")
+    exif = img.getexif()
+    exif[274] = 6
+    buf = BytesIO()
+    img.save(buf, format="JPEG", exif=exif)
+    return buf.getvalue()
+
+
+def test_orientation_flag_is_applied():
+    data = _make_orientation_6_image()
+    with Image.open(BytesIO(data)) as img:
+        assert get_orientation(img) == 6
+        original_size = img.size
+    normalized = normalize_orientation(data)
+    with Image.open(BytesIO(normalized)) as img:
+        corrected_size = img.size
+    assert original_size[1] > original_size[0]
+    assert corrected_size[0] > corrected_size[1]
+


### PR DESCRIPTION
## Summary
- handle EXIF orientation via new service
- rotate uploaded photos to correct orientation
- add tests for EXIF orientation handling without committing binary assets

## Testing
- `ruff check apps/server/app/services/exif.py apps/server/app/api/routes/photos.py apps/server/tests/test_exif.py`
- `PYTHONPATH=apps/server pytest apps/server/tests/test_exif.py`


------
https://chatgpt.com/codex/tasks/task_b_689b1f5527c8832b841ea545690f93d9