### PR TITLE
Add SQLModel session dependency and tests

### DIFF
--- a/apps/server/app/api/routes/locations.py
+++ b/apps/server/app/api/routes/locations.py
@@ -2,11 +2,12 @@ from fastapi import APIRouter, Depends, status
 from fastapi.responses import JSONResponse
 
 from app.core.security import get_current_user
+from app.db.session import get_session
 
 router = APIRouter(
     prefix="/locations",
     tags=["locations"],
-    dependencies=[Depends(get_current_user)],
+    dependencies=[Depends(get_current_user), Depends(get_session)],
 )
 
 

--- a/apps/server/app/db/session.py
+++ b/apps/server/app/db/session.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+import os
+from collections.abc import Generator
+
+from sqlmodel import Session, create_engine
+
+DATABASE_URL = os.getenv("DOKUSUITE_DATABASE_URL", "sqlite:///:memory:")
+
+connect_args: dict[str, bool] = {}
+if DATABASE_URL.startswith("sqlite"):
+    connect_args["check_same_thread"] = False
+
+engine = create_engine(DATABASE_URL, connect_args=connect_args)
+
+
+def get_session() -> Generator[Session, None, None]:
+    with Session(engine) as session:
+        yield session

--- a/apps/server/tests/test_db_session.py
+++ b/apps/server/tests/test_db_session.py
@@ -1,0 +1,29 @@
+import importlib
+
+from sqlmodel import Field, SQLModel
+
+
+def test_session_roundtrip(monkeypatch):
+    monkeypatch.setenv("DOKUSUITE_DATABASE_URL", "sqlite:///:memory:")
+    import app.db.session as session_module
+    session_module = importlib.reload(session_module)
+
+    class Location(SQLModel, table=True):
+        id: int | None = Field(default=None, primary_key=True)
+        name: str
+
+    SQLModel.metadata.create_all(session_module.engine)
+
+    session_gen = session_module.get_session()
+    session = next(session_gen)
+    try:
+        loc = Location(name="Test")
+        session.add(loc)
+        session.commit()
+        session.refresh(loc)
+
+        found = session.get(Location, loc.id)
+        assert found is not None
+        assert found.name == "Test"
+    finally:
+        session_gen.close()


### PR DESCRIPTION
## Summary
- create SQLModel engine and `get_session` dependency
- wire session dependency into locations routes
- add unit test for DB session roundtrip

## Testing
- `ruff check app/db/session.py app/api/routes/locations.py tests/test_db_session.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_689b252db4d4832b8112c4f3278026bf