### PR TITLE
Implement photo patch and batch assign endpoints

### DIFF
--- a/apps/server/app/api/schemas/__init__.py
+++ b/apps/server/app/api/schemas/__init__.py
@@ -1,13 +1,20 @@
 from .location import LocationRead
 from .pagination import Page
-from .photo import PhotoIngest, PhotoRead
+from .photo import (
+    BatchAssignRequest,
+    PhotoIngest,
+    PhotoRead,
+    PhotoUpdate,
+)
 from .upload import UploadIntent, UploadIntentRequest
 
 __all__ = [
     "LocationRead",
     "Page",
+    "BatchAssignRequest",
     "PhotoIngest",
     "PhotoRead",
+    "PhotoUpdate",
     "UploadIntent",
     "UploadIntentRequest",
 ]

--- a/apps/server/app/api/schemas/photo.py
+++ b/apps/server/app/api/schemas/photo.py
@@ -35,3 +35,14 @@ class PhotoRead(BaseModel):
     object_key: str
     taken_at: datetime
     status: str
+
+
+class PhotoUpdate(BaseModel):
+    quality_flag: str | None = None
+    note: str | None = None
+
+
+class BatchAssignRequest(BaseModel):
+    photo_ids: list[int]
+    order_id: int
+    calendar_week: str | None = None

--- a/apps/server/app/db/models.py
+++ b/apps/server/app/db/models.py
@@ -26,6 +26,9 @@ class Photo(SQLModel, table=True):
     status: str = "INGESTED"
     location_id: int | None = Field(default=None, foreign_key="location.id")
     order_id: int | None = Field(default=None, foreign_key="order.id")
+    quality_flag: str | None = Field(default=None)
+    note: str | None = Field(default=None)
+    calendar_week: str | None = Field(default=None)
 
 
 class Share(SQLModel, table=True):


### PR DESCRIPTION
## Summary
- support updating photo quality flag and note via `PATCH /photos/{photo_id}`
- allow assigning multiple photos to an order with optional calendar week via `POST /photos/batch/assign`
- add `PhotoUpdate` and `BatchAssignRequest` schemas and extend photo model
- cover new behavior with tests

## Testing
- `PYTHONPATH=apps/server pytest apps/server/tests/test_photos.py -q`


------
https://chatgpt.com/codex/tasks/task_b_689b3b9fd5dc832b8f6b47d88dade995