### PR TITLE
Add orders API endpoints with pagination

### DIFF
--- a/apps/server/app/api/routes/orders.py
+++ b/apps/server/app/api/routes/orders.py
@@ -1,16 +1,37 @@
-from fastapi import APIRouter, Depends, status
-from fastapi.responses import JSONResponse
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy import func
+from sqlmodel import Session, select
 
+from app.api.schemas import OrderRead, Page
 from app.core.security import get_current_user
+from app.db.models import Order
+from app.db.session import get_session
 
-router = APIRouter(prefix="/orders", tags=["orders"], dependencies=[Depends(get_current_user)])
+router = APIRouter(
+    prefix="/orders", tags=["orders"], dependencies=[Depends(get_current_user)]
+)
 
 
-@router.get("")
-def list_orders():
-    return JSONResponse({"status": "not_implemented"}, status_code=status.HTTP_501_NOT_IMPLEMENTED)
+@router.get("", response_model=Page[OrderRead])
+def list_orders(
+    customerId: str | None = None,
+    page: int = 1,
+    limit: int = 10,
+    session: Session = Depends(get_session),
+):
+    query = select(Order)
+    if customerId:
+        query = query.where(Order.customer_id == customerId)
+
+    total = session.exec(select(func.count()).select_from(query.subquery())).one()
+    results = session.exec(query.offset((page - 1) * limit).limit(limit)).all()
+    items = [OrderRead.model_validate(r, from_attributes=True) for r in results]
+    return Page(items=items, total=total, page=page, limit=limit)
 
 
-@router.get("/{order_id}")
-def get_order(order_id: str):
-    return JSONResponse({"status": "not_implemented"}, status_code=status.HTTP_501_NOT_IMPLEMENTED)
+@router.get("/{order_id}", response_model=OrderRead)
+def get_order(order_id: int, session: Session = Depends(get_session)):
+    order = session.get(Order, order_id)
+    if not order:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND)
+    return OrderRead.model_validate(order, from_attributes=True)

--- a/apps/server/app/api/schemas/__init__.py
+++ b/apps/server/app/api/schemas/__init__.py
@@ -6,6 +6,7 @@ from .photo import (
     PhotoRead,
     PhotoUpdate,
 )
+from .order import OrderRead
 from .upload import UploadIntent, UploadIntentRequest
 
 __all__ = [
@@ -17,4 +18,5 @@ __all__ = [
     "PhotoUpdate",
     "UploadIntent",
     "UploadIntentRequest",
+    "OrderRead",
 ]

--- a/apps/server/app/api/schemas/__init__.py
+++ b/apps/server/app/api/schemas/__init__.py
@@ -1,4 +1,5 @@
 from .location import LocationRead
+from .order import OrderRead
 from .pagination import Page
 from .photo import (
     BatchAssignRequest,
@@ -6,7 +7,6 @@ from .photo import (
     PhotoRead,
     PhotoUpdate,
 )
-from .order import OrderRead
 from .upload import UploadIntent, UploadIntentRequest
 
 __all__ = [

--- a/apps/server/app/api/schemas/order.py
+++ b/apps/server/app/api/schemas/order.py
@@ -1,0 +1,8 @@
+from pydantic import BaseModel
+
+
+class OrderRead(BaseModel):
+    id: int
+    customer_id: str
+    name: str
+    status: str

--- a/apps/server/tests/test_orders.py
+++ b/apps/server/tests/test_orders.py
@@ -1,0 +1,81 @@
+import importlib
+
+from fastapi.testclient import TestClient
+from sqlmodel import SQLModel
+
+from app.core.config import settings
+from app.core.security import create_access_token
+
+
+def make_client(monkeypatch):
+    monkeypatch.setenv("DOKUSUITE_DATABASE_URL", "sqlite:///:memory:")
+    import app.db.session as session_module
+    session_module = importlib.reload(session_module)
+    import app.db.models as models
+    SQLModel.metadata.clear()
+    models = importlib.reload(models)
+    SQLModel.metadata.create_all(session_module.engine)
+    import app.main as app_main
+    app_main = importlib.reload(app_main)
+    return TestClient(app_main.create_app()), session_module, models
+
+
+def auth_headers():
+    token = create_access_token(settings.admin_email, settings.access_token_expires_minutes)[
+        "access_token"
+    ]
+    return {"Authorization": f"Bearer {token}"}
+
+
+def test_orders_list(monkeypatch):
+    client, session_module, models = make_client(monkeypatch)
+    session_gen = session_module.get_session()
+    session = next(session_gen)
+    try:
+        session.add(models.Order(customer_id="c1", name="o1", status="NEW"))
+        session.add(models.Order(customer_id="c2", name="o2", status="NEW"))
+        session.commit()
+    finally:
+        session_gen.close()
+    r = client.get("/orders", headers=auth_headers())
+    assert r.status_code == 200
+    data = r.json()
+    assert data["total"] == 2
+    assert len(data["items"]) == 2
+
+
+def test_orders_filter(monkeypatch):
+    client, session_module, models = make_client(monkeypatch)
+    session_gen = session_module.get_session()
+    session = next(session_gen)
+    try:
+        session.add(models.Order(customer_id="c1", name="o1", status="NEW"))
+        session.add(models.Order(customer_id="c2", name="o2", status="NEW"))
+        session.commit()
+    finally:
+        session_gen.close()
+    r = client.get("/orders?customerId=c1", headers=auth_headers())
+    assert r.status_code == 200
+    data = r.json()
+    assert data["total"] == 1
+    assert len(data["items"]) == 1
+    assert data["items"][0]["customer_id"] == "c1"
+
+
+def test_get_order(monkeypatch):
+    client, session_module, models = make_client(monkeypatch)
+    session_gen = session_module.get_session()
+    session = next(session_gen)
+    try:
+        order = models.Order(customer_id="c1", name="o1", status="NEW")
+        session.add(order)
+        session.commit()
+        session.refresh(order)
+        order_id = order.id
+    finally:
+        session_gen.close()
+    r = client.get(f"/orders/{order_id}", headers=auth_headers())
+    assert r.status_code == 200
+    data = r.json()
+    assert data["id"] == order_id
+    assert data["customer_id"] == "c1"


### PR DESCRIPTION
## Summary
- implement `/orders` listing with pagination and optional `customerId`
- implement `/orders/{order_id}` retrieval
- add `OrderRead` schema and export
- cover orders listing, filtering, and retrieval with tests

## Testing
- `ruff check apps/server/tests/test_orders.py apps/server/app/api/routes/orders.py apps/server/app/api/schemas/order.py`
- `pytest apps/server/tests/test_orders.py -q`
- `pytest apps/server/tests/test_locations.py::test_locations_empty_list -q`


------
https://chatgpt.com/codex/tasks/task_b_689b3de67d5c832b9d66568db5ab9a43