### PR TITLE
Add share endpoints and tests

### DIFF
--- a/apps/server/app/api/routes/shares.py
+++ b/apps/server/app/api/routes/shares.py
@@ -1,21 +1,44 @@
-from fastapi import APIRouter, Depends, status
-from fastapi.responses import JSONResponse
+from fastapi import APIRouter, Depends, HTTPException, Response, status
+from sqlmodel import Session
+import secrets
 
+from app.api.schemas import ShareCreate, ShareRead
 from app.core.security import get_current_user
+from app.db.models import Share
+from app.db.session import get_session
 
-router = APIRouter(prefix="/shares", tags=["shares"], dependencies=[Depends(get_current_user)])
-
-
-@router.post("")
-def create_share():
-    return JSONResponse({"status": "not_implemented"}, status_code=status.HTTP_501_NOT_IMPLEMENTED)
-
-
-@router.get("/{share_id}")
-def get_share(share_id: str):
-    return JSONResponse({"status": "not_implemented"}, status_code=status.HTTP_501_NOT_IMPLEMENTED)
+router = APIRouter(
+    prefix="/shares", tags=["shares"], dependencies=[Depends(get_current_user)]
+)
 
 
-@router.post("/{share_id}/revoke")
-def revoke_share(share_id: str):
-    return JSONResponse({"status": "not_implemented"}, status_code=status.HTTP_501_NOT_IMPLEMENTED)
+@router.post("", response_model=ShareRead, status_code=status.HTTP_201_CREATED)
+def create_share(payload: ShareCreate, session: Session = Depends(get_session)):
+    share = Share(
+        order_id=payload.order_id,
+        url=f"https://example.com/{secrets.token_urlsafe(16)}",
+        expires_at=payload.expires_at,
+        download_allowed=payload.download_allowed,
+    )
+    session.add(share)
+    session.commit()
+    session.refresh(share)
+    return ShareRead.model_validate(share, from_attributes=True)
+
+
+@router.get("/{share_id}", response_model=ShareRead)
+def get_share(share_id: int, session: Session = Depends(get_session)):
+    share = session.get(Share, share_id)
+    if not share:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND)
+    return ShareRead.model_validate(share, from_attributes=True)
+
+
+@router.post("/{share_id}/revoke", status_code=status.HTTP_204_NO_CONTENT)
+def revoke_share(share_id: int, session: Session = Depends(get_session)):
+    share = session.get(Share, share_id)
+    if not share:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND)
+    session.delete(share)
+    session.commit()
+    return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/apps/server/app/api/routes/shares.py
+++ b/apps/server/app/api/routes/shares.py
@@ -1,6 +1,7 @@
+import secrets
+
 from fastapi import APIRouter, Depends, HTTPException, Response, status
 from sqlmodel import Session
-import secrets
 
 from app.api.schemas import ShareCreate, ShareRead
 from app.core.security import get_current_user

--- a/apps/server/app/api/schemas/__init__.py
+++ b/apps/server/app/api/schemas/__init__.py
@@ -8,6 +8,7 @@ from .photo import (
     PhotoUpdate,
 )
 from .upload import UploadIntent, UploadIntentRequest
+from .share import ShareCreate, ShareRead
 
 __all__ = [
     "LocationRead",
@@ -19,4 +20,6 @@ __all__ = [
     "UploadIntent",
     "UploadIntentRequest",
     "OrderRead",
+    "ShareCreate",
+    "ShareRead",
 ]

--- a/apps/server/app/api/schemas/__init__.py
+++ b/apps/server/app/api/schemas/__init__.py
@@ -1,14 +1,9 @@
 from .location import LocationRead
 from .order import OrderRead
 from .pagination import Page
-from .photo import (
-    BatchAssignRequest,
-    PhotoIngest,
-    PhotoRead,
-    PhotoUpdate,
-)
-from .upload import UploadIntent, UploadIntentRequest
+from .photo import BatchAssignRequest, PhotoIngest, PhotoRead, PhotoUpdate
 from .share import ShareCreate, ShareRead
+from .upload import UploadIntent, UploadIntentRequest
 
 __all__ = [
     "LocationRead",

--- a/apps/server/app/api/schemas/share.py
+++ b/apps/server/app/api/schemas/share.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+
 from pydantic import BaseModel
 
 

--- a/apps/server/app/api/schemas/share.py
+++ b/apps/server/app/api/schemas/share.py
@@ -1,0 +1,16 @@
+from datetime import datetime
+from pydantic import BaseModel
+
+
+class ShareCreate(BaseModel):
+    order_id: int
+    expires_at: datetime | None = None
+    download_allowed: bool = True
+
+
+class ShareRead(BaseModel):
+    id: int
+    order_id: int
+    url: str
+    expires_at: datetime | None = None
+    download_allowed: bool

--- a/apps/server/app/main.py
+++ b/apps/server/app/main.py
@@ -7,6 +7,7 @@ from .api.routes import ingestion as ingestion_routes
 from .api.routes import locations as location_routes
 from .api.routes import orders as order_routes
 from .api.routes import photos as photo_routes
+from .api.routes import shares as share_routes
 from .core.config import settings
 
 
@@ -18,6 +19,7 @@ def create_app() -> FastAPI:
     app.include_router(location_routes.router)
     app.include_router(photo_routes.router)
     app.include_router(order_routes.router)
+    app.include_router(share_routes.router)
     app.include_router(export_routes.router)
     return app
 

--- a/apps/server/tests/test_shares.py
+++ b/apps/server/tests/test_shares.py
@@ -1,0 +1,114 @@
+import importlib
+
+from fastapi.testclient import TestClient
+from sqlmodel import SQLModel
+
+from app.core.config import settings
+from app.core.security import create_access_token
+
+
+def make_client(monkeypatch):
+    monkeypatch.setenv("DOKUSUITE_DATABASE_URL", "sqlite:///:memory:")
+    import app.db.session as session_module
+    session_module = importlib.reload(session_module)
+    import app.db.models as models
+    SQLModel.metadata.clear()
+    models = importlib.reload(models)
+    SQLModel.metadata.create_all(session_module.engine)
+    import app.main as app_main
+    app_main = importlib.reload(app_main)
+    return TestClient(app_main.create_app()), session_module, models
+
+
+def auth_headers():
+    token = create_access_token(settings.admin_email, settings.access_token_expires_minutes)[
+        "access_token"
+    ]
+    return {"Authorization": f"Bearer {token}"}
+
+
+def test_create_share(monkeypatch):
+    client, session_module, models = make_client(monkeypatch)
+    session_gen = session_module.get_session()
+    session = next(session_gen)
+    try:
+        order = models.Order(customer_id="c1", name="o1", status="NEW")
+        session.add(order)
+        session.commit()
+        session.refresh(order)
+        order_id = order.id
+    finally:
+        session_gen.close()
+
+    payload = {"order_id": order_id}
+    r = client.post("/shares", json=payload, headers=auth_headers())
+    assert r.status_code == 201
+    data = r.json()
+    assert data["order_id"] == order_id
+    assert data["url"]
+
+    share_id = data["id"]
+    session_gen = session_module.get_session()
+    session = next(session_gen)
+    try:
+        share = session.get(models.Share, share_id)
+        assert share is not None
+        assert share.order_id == order_id
+    finally:
+        session_gen.close()
+
+
+def test_get_share(monkeypatch):
+    client, session_module, models = make_client(monkeypatch)
+    session_gen = session_module.get_session()
+    session = next(session_gen)
+    try:
+        order = models.Order(customer_id="c1", name="o1", status="NEW")
+        session.add(order)
+        session.commit()
+        session.refresh(order)
+        order_id = order.id
+        share = models.Share(order_id=order_id, url="u1")
+        session.add(share)
+        session.commit()
+        session.refresh(share)
+        share_id = share.id
+    finally:
+        session_gen.close()
+
+    r = client.get(f"/shares/{share_id}", headers=auth_headers())
+    assert r.status_code == 200
+    data = r.json()
+    assert data["id"] == share_id
+    assert data["order_id"] == order_id
+
+
+def test_revoke_share(monkeypatch):
+    client, session_module, models = make_client(monkeypatch)
+    session_gen = session_module.get_session()
+    session = next(session_gen)
+    try:
+        order = models.Order(customer_id="c1", name="o1", status="NEW")
+        session.add(order)
+        session.commit()
+        session.refresh(order)
+        share = models.Share(order_id=order.id, url="u1")
+        session.add(share)
+        session.commit()
+        session.refresh(share)
+        share_id = share.id
+    finally:
+        session_gen.close()
+
+    r = client.post(f"/shares/{share_id}/revoke", headers=auth_headers())
+    assert r.status_code == 204
+
+    session_gen = session_module.get_session()
+    session = next(session_gen)
+    try:
+        assert session.get(models.Share, share_id) is None
+    finally:
+        session_gen.close()
+
+    r = client.get(f"/shares/{share_id}", headers=auth_headers())
+    assert r.status_code == 404


### PR DESCRIPTION
## Summary
- implement share creation, retrieval, and revocation endpoints
- add ShareCreate and ShareRead schemas
- cover share lifecycle with tests

## Testing
- `PYTHONPATH=apps/server pytest apps/server/tests/test_shares.py`
- `PYTHONPATH=apps/server pytest apps/server/tests`


------
https://chatgpt.com/codex/tasks/task_b_689b416775a8832bbff7b7e0ec2b604d