### PR TITLE
Add export job endpoints and tests

### DIFF
--- a/apps/server/tests/test_exports.py
+++ b/apps/server/tests/test_exports.py
@@ -1,0 +1,73 @@
+import importlib
+
+from fastapi.testclient import TestClient
+
+from app.core.config import settings
+from app.core.security import create_access_token
+
+
+def make_client(monkeypatch):
+    import app.api.routes.exports as exports_module
+
+    calls: dict[str, bool] = {}
+
+    class JobStub:
+        def __init__(self, id: str):
+            self.id = id
+
+    def fake_zip():
+        calls["zip"] = True
+        return JobStub("zip-id")
+
+    def fake_excel():
+        calls["excel"] = True
+        return JobStub("excel-id")
+
+    monkeypatch.setattr(exports_module, "enqueue_export_zip", lambda: fake_zip())
+    monkeypatch.setattr(exports_module, "enqueue_export_excel", lambda: fake_excel())
+
+    import app.main as app_main
+    app_main = importlib.reload(app_main)
+    client = TestClient(app_main.create_app())
+    return client, exports_module, calls
+
+
+def auth_headers():
+    token = create_access_token(settings.admin_email, settings.access_token_expires_minutes)[
+        "access_token"
+    ]
+    return {"Authorization": f"Bearer {token}"}
+
+
+def test_export_zip_job(monkeypatch):
+    client, _exports, calls = make_client(monkeypatch)
+    r = client.post("/exports/zip", headers=auth_headers())
+    assert r.status_code == 200
+    assert r.json()["export_id"] == "zip-id"
+    assert calls["zip"]
+
+
+def test_export_excel_job(monkeypatch):
+    client, _exports, calls = make_client(monkeypatch)
+    r = client.post("/exports/excel", headers=auth_headers())
+    assert r.status_code == 200
+    assert r.json()["export_id"] == "excel-id"
+    assert calls["excel"]
+
+
+def test_get_export_status(monkeypatch):
+    client, exports_module, _ = make_client(monkeypatch)
+
+    class JobStub:
+        def get_status(self):
+            return "finished"
+
+    monkeypatch.setattr(
+        exports_module.Job,
+        "fetch",
+        classmethod(lambda cls, job_id, connection=None: JobStub()),
+    )
+
+    r = client.get("/exports/any", headers=auth_headers())
+    assert r.status_code == 200
+    assert r.json() == {"status": "finished"}

--- a/packages/workers/ingestion/jobs.py
+++ b/packages/workers/ingestion/jobs.py
@@ -4,3 +4,13 @@ from typing import Any
 def ingest(payload: dict[str, Any]) -> None:
     """Placeholder ingestion job."""
     print(f"Ingesting payload: {payload}")
+
+
+def export_zip(payload: dict[str, Any] | None = None) -> None:
+    """Placeholder job for generating ZIP exports."""
+    print(f"Exporting ZIP with payload: {payload}")
+
+
+def export_excel(payload: dict[str, Any] | None = None) -> None:
+    """Placeholder job for generating Excel exports."""
+    print(f"Exporting Excel with payload: {payload}")

--- a/packages/workers/ingestion/queue.py
+++ b/packages/workers/ingestion/queue.py
@@ -14,3 +14,13 @@ queue = Queue("ingestion", connection=_redis)
 def enqueue_ingest(payload: dict[str, Any]) -> Any:
     """Enqueue an ingestion job."""
     return queue.enqueue(jobs.ingest, payload)
+
+
+def enqueue_export_zip(payload: dict[str, Any] | None = None) -> Any:
+    """Enqueue a ZIP export job."""
+    return queue.enqueue(jobs.export_zip, payload)
+
+
+def enqueue_export_excel(payload: dict[str, Any] | None = None) -> Any:
+    """Enqueue an Excel export job."""
+    return queue.enqueue(jobs.export_excel, payload)


### PR DESCRIPTION
## Summary
- Queue ZIP and Excel export jobs and expose export status via new API endpoints
- Add worker stubs and queue helpers for export jobs
- Cover export job creation and status retrieval with tests

## Testing
- `PYTHONPATH=apps/server pytest apps/server/tests/test_exports.py`


------
https://chatgpt.com/codex/tasks/task_b_689b45e72618832b8eaf67fb06032398