### PR TITLE
Add repository-wide AGENTS instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,22 @@
+# AGENTS Instructions
+
+These instructions apply to the entire repository.
+
+## Documentation
+
+Planning and specification documents live in the [`docs/`](docs/README.md) directory. The [docs/README.md](docs/README.md) file lists vision, requirements, architecture, data model, and other project documentation for each subdomain. Update the relevant documents when code changes affect specifications or goals.
+
+## Development Guidelines
+
+- Keep code organised within existing folders (`apps`, `packages`, `infra`).
+- Follow language-appropriate style conventions (PEP 8 for Python, Prettier/ESLint for JavaScript/TypeScript, Xcode conventions for Swift).
+- Use type hints and add or update unit tests alongside code changes.
+
+## Testing
+
+Run tests before committing:
+
+- **Python**: `pytest` (e.g. `pytest apps/server/tests`).
+- **JavaScript/TypeScript**: `npm test` inside the relevant project directory.
+- **iOS/Swift**: `xcodebuild test` where applicable.
+


### PR DESCRIPTION
## Summary
- add AGENTS.md with repository-wide development and testing guidelines
- note that planning documents reside in docs/README.md

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'fastapi')*
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_689b87dd7b18832b85e1af36f6eb21b9