### PR TITLE
feat(server): add user auth

### DIFF
--- a/apps/server/app/db/models.py
+++ b/apps/server/app/db/models.py
@@ -19,6 +19,18 @@ else:  # SQLite fallback used in tests
     _geog_column = Column(String, nullable=True)
 
 
+class User(SQLModel, table=True):
+    id: int | None = Field(default=None, primary_key=True)
+    email: str = Field(sa_column=Column(String, nullable=False, unique=True))
+    password_hash: str = Field(sa_column=Column(String, nullable=False))
+    created_at: datetime = Field(
+        default_factory=datetime.utcnow,
+        sa_column=Column(
+            DateTime(timezone=True), nullable=False, server_default=func.now()
+        ),
+    )
+
+
 class Location(SQLModel, table=True):
     id: int | None = Field(default=None, primary_key=True)
     name: str

--- a/apps/server/migrations/versions/c4e14335c43d_add_user_table.py
+++ b/apps/server/migrations/versions/c4e14335c43d_add_user_table.py
@@ -1,0 +1,35 @@
+"""add user table
+
+Revision ID: c4e14335c43d
+Revises: b2d96ab19384
+Create Date: 2025-08-12 15:00:00.000000
+
+"""
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "c4e14335c43d"
+down_revision = "b2d96ab19384"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "user",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("email", sa.String(), nullable=False),
+        sa.Column("password_hash", sa.String(), nullable=False),
+        sa.Column(
+            "created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("email"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("user")


### PR DESCRIPTION
## Summary
- add User model and migration
- add register and db-backed login endpoints
- test user registration and login

## Testing
- `ruff check apps/server`
- `pytest apps/server`


------
https://chatgpt.com/codex/tasks/task_b_689b88095538832b9f4ce540bdf24858