### PR TITLE
feat: add JSON logging and metrics to server

### DIFF
--- a/apps/server/README.md
+++ b/apps/server/README.md
@@ -13,6 +13,11 @@ Minimaler Start für den Backend‑Service inkl. Health‑Endpoint.
 - Lint:
   - `ruff check .`
 
+## Logging & Monitoring
+- Logs werden im JSON‑Format ausgegeben.
+- Jeder Request erhält eine `X-Request-ID` und wird mit Dauer sowie Statuscode geloggt.
+- Prometheus‑Metrics unter `GET /metrics`, inkl. Request‑Counter und Gauge für laufende Requests.
+
 ## Migrationen
 - Neue Revision erzeugen:
   - `alembic revision --autogenerate -m "message"`

--- a/apps/server/app/core/logging.py
+++ b/apps/server/app/core/logging.py
@@ -1,0 +1,30 @@
+import json
+import logging
+from typing import Any
+
+
+class JsonFormatter(logging.Formatter):
+    """Format log records as JSON."""
+
+    def format(self, record: logging.LogRecord) -> str:
+        log_record: dict[str, Any] = {
+            "timestamp": self.formatTime(record, self.datefmt),
+            "level": record.levelname,
+            "message": record.getMessage(),
+        }
+        if hasattr(record, "request_id"):
+            log_record["request_id"] = record.request_id
+        if hasattr(record, "duration_ms"):
+            log_record["duration_ms"] = record.duration_ms
+        if hasattr(record, "status_code"):
+            log_record["status_code"] = record.status_code
+        return json.dumps(log_record)
+
+
+def configure_logging() -> None:
+    """Configure root logger to use JSON formatting."""
+    handler = logging.StreamHandler()
+    handler.setFormatter(JsonFormatter())
+    root_logger = logging.getLogger()
+    root_logger.handlers = [handler]
+    root_logger.setLevel(logging.INFO)

--- a/apps/server/app/core/metrics.py
+++ b/apps/server/app/core/metrics.py
@@ -1,0 +1,22 @@
+from fastapi import APIRouter, Response
+from prometheus_client import CONTENT_TYPE_LATEST, Counter, Gauge, generate_latest
+
+router = APIRouter()
+
+REQUEST_COUNTER = Counter(
+    "dokusuite_requests_total",
+    "Total HTTP requests",
+    ["method", "path", "status_code"],
+)
+
+IN_PROGRESS_GAUGE = Gauge(
+    "dokusuite_requests_in_progress",
+    "In-progress HTTP requests",
+    ["path"],
+)
+
+
+@router.get("/metrics")
+def metrics() -> Response:
+    """Expose Prometheus metrics."""
+    return Response(generate_latest(), media_type=CONTENT_TYPE_LATEST)

--- a/apps/server/app/core/middleware.py
+++ b/apps/server/app/core/middleware.py
@@ -1,0 +1,36 @@
+import logging
+import time
+import uuid
+
+from fastapi import Request
+from starlette.middleware.base import BaseHTTPMiddleware
+
+from .metrics import IN_PROGRESS_GAUGE, REQUEST_COUNTER
+
+
+class RequestMetricsMiddleware(BaseHTTPMiddleware):
+    """Track request metrics and enrich logs."""
+
+    async def dispatch(self, request: Request, call_next):
+        request_id = str(uuid.uuid4())
+        request.state.request_id = request_id
+        start_time = time.perf_counter()
+        IN_PROGRESS_GAUGE.labels(path=request.url.path).inc()
+        try:
+            response = await call_next(request)
+        finally:
+            IN_PROGRESS_GAUGE.labels(path=request.url.path).dec()
+        duration_ms = (time.perf_counter() - start_time) * 1000
+        response.headers["X-Request-ID"] = request_id
+        REQUEST_COUNTER.labels(
+            method=request.method, path=request.url.path, status_code=response.status_code
+        ).inc()
+        logging.getLogger(__name__).info(
+            "request completed",
+            extra={
+                "request_id": request_id,
+                "duration_ms": round(duration_ms, 2),
+                "status_code": response.status_code,
+            },
+        )
+        return response

--- a/apps/server/app/main.py
+++ b/apps/server/app/main.py
@@ -9,10 +9,16 @@ from .api.routes import orders as order_routes
 from .api.routes import photos as photo_routes
 from .api.routes import shares as share_routes
 from .core.config import settings
+from .core.logging import configure_logging
+from .core.metrics import router as metrics_router
+from .core.middleware import RequestMetricsMiddleware
 
 
 def create_app() -> FastAPI:
+    configure_logging()
     app = FastAPI(title=settings.app_name)
+    app.add_middleware(RequestMetricsMiddleware)
+    app.include_router(metrics_router)
     app.include_router(health_routes.router)
     app.include_router(ingestion_routes.router)
     app.include_router(auth_routes.router)

--- a/apps/server/pyproject.toml
+++ b/apps/server/pyproject.toml
@@ -24,6 +24,7 @@ dependencies = [
   "Pillow>=10.0",
   "openpyxl>=3.1",
   "python-multipart>=0.0.6",
+  "prometheus-client>=0.20",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Summary
- output server logs as JSON
- track request IDs, timing, status via middleware
- expose Prometheus metrics with request counter and gauge

## Testing
- `ruff check .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_689ba3f403f4832b831ef0118641cf52