### PR TITLE
feat: add role-based access control

### DIFF
--- a/apps/server/app/core/security.py
+++ b/apps/server/app/core/security.py
@@ -2,11 +2,14 @@ from datetime import UTC, datetime, timedelta
 from typing import Any
 
 import jwt
-from fastapi import HTTPException, Security, status
+from fastapi import Depends, HTTPException, Security, status
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from passlib.context import CryptContext
+from sqlmodel import Session, select
 
 from .config import settings
+from app.db.models import User as UserModel
+from app.db.session import get_session
 
 pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
 
@@ -58,8 +61,9 @@ def decode_token(token: str) -> dict[str, Any]:
 
 
 class User:
-    def __init__(self, email: str):
+    def __init__(self, email: str, role: str):
         self.email = email
+        self.role = role
 
 
 bearer_scheme = HTTPBearer(auto_error=False)
@@ -67,6 +71,7 @@ bearer_scheme = HTTPBearer(auto_error=False)
 
 def get_current_user(
     credentials: HTTPAuthorizationCredentials | None = Security(bearer_scheme),
+    session: Session = Depends(get_session),
 ) -> User:
     if credentials is None or credentials.scheme.lower() != "bearer":
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Not authenticated")
@@ -77,4 +82,26 @@ def get_current_user(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Invalid token payload",
         )
-    return User(email=str(sub))
+    if sub == settings.admin_email:
+        role = "ADMIN"
+    else:
+        user = session.exec(select(UserModel).where(UserModel.email == sub)).first()
+        if user is None:
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="Invalid token payload",
+            )
+        role = user.role.value if hasattr(user.role, "value") else str(user.role)
+    return User(email=str(sub), role=role)
+
+
+def require_role(*roles: str):
+    def dependency(user: User = Depends(get_current_user)) -> User:
+        if user.role not in roles:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="Forbidden",
+            )
+        return user
+
+    return dependency

--- a/apps/server/app/db/models.py
+++ b/apps/server/app/db/models.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import os
 from datetime import datetime
+from enum import Enum
 
 from sqlalchemy import JSON, Column, DateTime, String, UniqueConstraint, func
 from sqlmodel import Field, SQLModel
@@ -19,10 +20,19 @@ else:  # SQLite fallback used in tests
     _geog_column = Column(String, nullable=True)
 
 
+class UserRole(str, Enum):
+    ADMIN = "ADMIN"
+    USER = "USER"
+
+
 class User(SQLModel, table=True):
     id: int | None = Field(default=None, primary_key=True)
     email: str = Field(sa_column=Column(String, nullable=False, unique=True))
     password_hash: str = Field(sa_column=Column(String, nullable=False))
+    role: UserRole = Field(
+        default=UserRole.USER,
+        sa_column=Column(String, nullable=False),
+    )
     created_at: datetime = Field(
         default_factory=datetime.utcnow,
         sa_column=Column(

--- a/apps/server/tests/test_auth_guard.py
+++ b/apps/server/tests/test_auth_guard.py
@@ -1,6 +1,22 @@
+import importlib
+
 from fastapi.testclient import TestClient
+from sqlmodel import SQLModel
 
 from app.main import create_app
+
+
+def make_client(monkeypatch):
+    monkeypatch.setenv("DOKUSUITE_DATABASE_URL", "sqlite:///:memory:")
+    import app.db.session as session_module
+    session_module = importlib.reload(session_module)
+    import app.db.models as models
+    SQLModel.metadata.clear()
+    models = importlib.reload(models)
+    SQLModel.metadata.create_all(session_module.engine)
+    import app.main as app_main
+    app_main = importlib.reload(app_main)
+    return TestClient(app_main.create_app()), session_module, models
 
 
 def test_me_requires_auth(monkeypatch):
@@ -24,4 +40,66 @@ def test_me_with_valid_token(monkeypatch):
     assert r.status_code == 200
     body = r.json()
     assert body.get("email") == settings.admin_email
+
+
+def test_orders_require_admin_role(monkeypatch):
+    from app.core.config import settings
+    from app.core.security import create_access_token
+
+    client, session_module, models = make_client(monkeypatch)
+
+    session_gen = session_module.get_session()
+    session = next(session_gen)
+    try:
+        session.add(models.User(email="user@example.com", password_hash="pw"))
+        session.commit()
+    finally:
+        session_gen.close()
+
+    user_token = create_access_token(
+        "user@example.com", settings.access_token_expires_minutes
+    )["access_token"]
+    r = client.get("/orders", headers={"Authorization": f"Bearer {user_token}"})
+    assert r.status_code == 403
+
+    admin_token = create_access_token(
+        settings.admin_email, settings.access_token_expires_minutes
+    )["access_token"]
+    r = client.get("/orders", headers={"Authorization": f"Bearer {admin_token}"})
+    assert r.status_code == 200
+
+
+def test_shares_require_admin_role(monkeypatch):
+    from app.core.config import settings
+    from app.core.security import create_access_token
+
+    client, session_module, models = make_client(monkeypatch)
+
+    session_gen = session_module.get_session()
+    session = next(session_gen)
+    try:
+        session.add(models.User(email="user@example.com", password_hash="pw"))
+        order = models.Order(customer_id="c1", name="o1", status="NEW")
+        session.add(order)
+        session.commit()
+        session.refresh(order)
+        order_id = order.id
+    finally:
+        session_gen.close()
+
+    user_token = create_access_token(
+        "user@example.com", settings.access_token_expires_minutes
+    )["access_token"]
+    r = client.post(
+        "/shares", json={"order_id": order_id}, headers={"Authorization": f"Bearer {user_token}"}
+    )
+    assert r.status_code == 403
+
+    admin_token = create_access_token(
+        settings.admin_email, settings.access_token_expires_minutes
+    )["access_token"]
+    r = client.post(
+        "/shares", json={"order_id": order_id}, headers={"Authorization": f"Bearer {admin_token}"}
+    )
+    assert r.status_code == 201
 

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -6,7 +6,7 @@ Kern-Entitäten:
 - Foto: Datei-Refs (Original, Thumbs), EXIF, Zeit, GPS, Qualität/Flags, pHash, Status.
 - Auftrag (Kundenauftrag/Kampagne): Kunde, Zeitraum(e), Ziele, Verknüpfung zu Standorten/Fotos.
 - Belegung/Platzierung: Zuordnung Foto ↔ Standort ↔ Belegungswoche/-fenster.
-- Nutzer: Rollen (Admin, Team, Plakatierer, Kunde), Organisation/Zugehörigkeit.
+- Nutzer: Rollen (z. B. `ADMIN`, `USER`), Organisation/Zugehörigkeit.
 - Lieferant/Partner: Subunternehmer, Zuordnung zu Nutzern/Teams.
  - Share/Freigabe: Kundenfreigaben inkl. Ablauf, Branding/Wasserzeichen-Policy, Download-Flags.
 


### PR DESCRIPTION
## Summary
- add `role` field to user model
- implement `require_role` dependency and secure orders/shares routes
- test role enforcement and document user roles

## Testing
- `ruff check app tests`
- `pytest apps/server/tests`

------
https://chatgpt.com/codex/tasks/task_b_689bab4075cc832b8388ba2bb8741651