### PR TITLE
Restrict photo upload intent

### DIFF
--- a/apps/server/app/api/schemas/upload.py
+++ b/apps/server/app/api/schemas/upload.py
@@ -1,9 +1,20 @@
+"""Pydantic models related to uploads."""
+
 from pydantic import BaseModel, ConfigDict, Field
+
+# Only images are accepted for uploads.
+ALLOWED_MIME_PREFIX = "image/"
+# Maximum allowed size of an uploaded file in bytes (10 MiB).
+MAX_FILE_SIZE = 10 * 1024 * 1024
 
 
 class UploadIntentRequest(BaseModel):
-    content_type: str = Field(..., alias="contentType")
-    size: int = Field(..., ge=1)
+    """Client request to obtain a signed upload URL."""
+
+    content_type: str = Field(
+        ..., alias="contentType", description="MIME type of the file (image/* only)"
+    )
+    size: int = Field(..., ge=1, description="Size of the file in bytes")
 
     model_config = ConfigDict(populate_by_name=True)
 


### PR DESCRIPTION
## Summary
- define image-only uploads and max file size for upload intent
- enforce upload size and content type when generating S3 upload posts
- cover invalid content type and size in upload intent tests

## Testing
- `ruff check apps/server`
- `pytest apps/server`


------
https://chatgpt.com/codex/tasks/task_b_689bbb50d740832b9ad82acced2f5fc7