### PR TITLE
Accept export payload and forward to worker queue

### DIFF
--- a/apps/server/app/api/routes/exports.py
+++ b/apps/server/app/api/routes/exports.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 import boto3
 from fastapi import APIRouter, Depends, HTTPException, status
 from rq.exceptions import NoSuchJobError
@@ -24,15 +26,15 @@ def _s3_client():
     )
 
 
-@router.post("/zip")
-def export_zip():
-    job = enqueue_export_zip()
+@router.post("/zip", status_code=status.HTTP_202_ACCEPTED)
+def export_zip(payload: dict[str, Any] | None = None):
+    job = enqueue_export_zip(payload)
     return {"export_id": job.id}
 
 
-@router.post("/excel")
-def export_excel():
-    job = enqueue_export_excel()
+@router.post("/excel", status_code=status.HTTP_202_ACCEPTED)
+def export_excel(payload: dict[str, Any] | None = None):
+    job = enqueue_export_excel(payload)
     return {"export_id": job.id}
 
 


### PR DESCRIPTION
## Summary
- parse optional JSON payload in export routes and forward to worker jobs
- return 202 ACCEPTED from export endpoints
- test parameter forwarding for ZIP and Excel exports

## Testing
- `ruff check apps/server/app/api/routes/exports.py`
- `pytest apps/server/tests/test_exports.py`


------
https://chatgpt.com/codex/tasks/task_b_689c3b43caa0832b866d86f72ef49c4b