### PR TITLE
feat(server): add optional OpenTelemetry tracing

### DIFF
--- a/apps/server/README.md
+++ b/apps/server/README.md
@@ -17,6 +17,11 @@ Minimaler Start für den Backend‑Service inkl. Health‑Endpoint.
 - Logs werden im JSON‑Format ausgegeben.
 - Jeder Request erhält eine `X-Request-ID` und wird mit Dauer sowie Statuscode geloggt.
 - Prometheus‑Metrics unter `GET /metrics`, inkl. Request‑Counter und Gauge für laufende Requests.
+- Optionales Tracing mit OpenTelemetry:
+  - Installation: `pip install -e .[opentelemetry]`
+  - Aktivierung über Environment:
+    - `DOKUSUITE_TRACING_EXPORTER=otlp`
+    - optional `DOKUSUITE_TRACING_ENDPOINT=http://localhost:4317`
 
 ## Migrationen
 - Neue Revision erzeugen:

--- a/apps/server/app/core/config.py
+++ b/apps/server/app/core/config.py
@@ -31,6 +31,10 @@ class Settings(BaseSettings):
     smtp_password: str | None = None
     smtp_from: str = "no-reply@example.com"
 
+    # OpenTelemetry tracing
+    tracing_exporter: str | None = None  # e.g. "otlp"
+    tracing_endpoint: str | None = None
+
     # Pydantic v2 style config
     model_config = SettingsConfigDict(env_prefix="DOKUSUITE_")
 

--- a/apps/server/app/main.py
+++ b/apps/server/app/main.py
@@ -13,6 +13,30 @@ from .core.logging import configure_logging
 from .core.metrics import router as metrics_router
 from .core.middleware import RequestMetricsMiddleware
 
+try:  # optional OpenTelemetry
+    from opentelemetry import trace
+    from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
+    from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
+    from opentelemetry.sdk.resources import Resource
+    from opentelemetry.sdk.trace import TracerProvider
+    from opentelemetry.sdk.trace.export import BatchSpanProcessor
+except Exception:  # pragma: no cover - optional dependency
+    FastAPIInstrumentor = None
+
+
+def configure_tracing(app: FastAPI) -> None:
+    if not FastAPIInstrumentor or not settings.tracing_exporter:
+        return
+    if settings.tracing_exporter == "otlp":
+        exporter = OTLPSpanExporter(endpoint=settings.tracing_endpoint)
+    else:
+        return
+    resource = Resource.create({"service.name": settings.app_name})
+    provider = TracerProvider(resource=resource)
+    provider.add_span_processor(BatchSpanProcessor(exporter))
+    trace.set_tracer_provider(provider)
+    FastAPIInstrumentor.instrument_app(app)
+
 
 def create_app() -> FastAPI:
     configure_logging()
@@ -28,6 +52,7 @@ def create_app() -> FastAPI:
     app.include_router(share_routes.router)
     app.include_router(share_routes.public_router)
     app.include_router(export_routes.router)
+    configure_tracing(app)
     return app
 
 

--- a/apps/server/pyproject.toml
+++ b/apps/server/pyproject.toml
@@ -34,6 +34,12 @@ dev = [
   "httpx>=0.27",
   "ruff>=0.5",
 ]
+opentelemetry = [
+  "opentelemetry-api>=1.27",
+  "opentelemetry-sdk>=1.27",
+  "opentelemetry-instrumentation-fastapi>=0.45b0",
+  "opentelemetry-exporter-otlp>=1.27",
+]
 
 [tool.setuptools.packages.find]
 include = ["app*"]

--- a/apps/server/tests/test_tracing.py
+++ b/apps/server/tests/test_tracing.py
@@ -1,0 +1,15 @@
+import pytest
+from fastapi import FastAPI
+
+from app.core.config import settings
+from app.main import FastAPIInstrumentor, configure_tracing
+
+
+def test_configure_tracing_otlp(monkeypatch):
+    if FastAPIInstrumentor is None:
+        pytest.skip("OpenTelemetry not installed")
+    app = FastAPI()
+    monkeypatch.setattr(settings, "tracing_exporter", "otlp")
+    monkeypatch.setattr(settings, "tracing_endpoint", None)
+    configure_tracing(app)
+


### PR DESCRIPTION
## Summary
- add optional `opentelemetry` feature to server package
- configure tracing via `DOKUSUITE_TRACING_*` environment variables
- document and test tracing support

## Testing
- `ruff check .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_689c442b0510832bb4cf636c7dfbe8b1