### PR TITLE
feat: add invitation acceptance endpoint

### DIFF
--- a/packages/contracts/openapi.yaml
+++ b/packages/contracts/openapi.yaml
@@ -57,6 +57,27 @@ paths:
         '401':
           $ref: '#/components/responses/Unauthorized'
 
+  /auth/accept:
+    post:
+      tags: [auth]
+      summary: Accept invitation with token and password
+      security: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/InviteAcceptRequest'
+      responses:
+        '200':
+          description: JWT access token
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AuthToken'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
   /locations:
     get:
       tags: [locations]
@@ -465,6 +486,12 @@ components:
         access_token: { type: string }
         token_type: { type: string, example: Bearer }
         expires_in: { type: integer, example: 3600 }
+    InviteAcceptRequest:
+      type: object
+      required: [token, password]
+      properties:
+        token: { type: string }
+        password: { type: string, minLength: 1 }
     Location:
       type: object
       properties:


### PR DESCRIPTION
## Summary
- handle invitation acceptance with new `/auth/accept` endpoint creating users and issuing JWT
- document `POST /auth/accept` and `InviteAcceptRequest` schema in OpenAPI
- cover valid and invalid token scenarios with tests

## Testing
- `ruff check apps/server packages/contracts`
- `pytest apps/server/tests/test_auth.py`


------
https://chatgpt.com/codex/tasks/task_b_689c4dd286e0832b86fe6d645f188503