### PR TITLE
Ensure FastAPI is imported before create_app

### DIFF
--- a/apps/server/app/main.py
+++ b/apps/server/app/main.py
@@ -38,6 +38,9 @@ def configure_tracing(app: FastAPI) -> None:
     FastAPIInstrumentor.instrument_app(app)
 
 
+from fastapi import FastAPI
+
+
 def create_app() -> FastAPI:
     configure_logging()
     app = FastAPI(title=settings.app_name)


### PR DESCRIPTION
## Summary
- insert FastAPI import directly above the `create_app` function in the server app

## Testing
- `pytest apps/server/tests`


------
https://chatgpt.com/codex/tasks/task_b_689c5c639c68832bb5d6bfec00c80413