### PR TITLE
Add os and json imports to geocoding service

### DIFF
--- a/apps/server/app/services/geocoding.py
+++ b/apps/server/app/services/geocoding.py
@@ -1,5 +1,5 @@
-import json
 import os
+import json
 import urllib.parse
 import urllib.request
 from typing import Any


### PR DESCRIPTION
## Summary
- import os and json at the beginning of the geocoding service

## Testing
- `pytest apps/server/tests`


------
https://chatgpt.com/codex/tasks/task_b_689c5c627d84832ba8ef265023b1cb3f