### PR TITLE
feat(web): add user management page

### DIFF
--- a/apps/web/jest.config.ts
+++ b/apps/web/jest.config.ts
@@ -1,4 +1,4 @@
-import nextJest from 'next/jest'
+import nextJest from 'next/jest.js'
 
 const createJestConfig = nextJest({
   dir: './',

--- a/apps/web/src/pages/__tests__/users.test.tsx
+++ b/apps/web/src/pages/__tests__/users.test.tsx
@@ -1,0 +1,83 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import UsersPage from '../users'
+import { apiClient } from '../../../lib/api'
+
+jest.mock('../../../lib/api', () => ({
+  apiClient: {
+    GET: jest.fn(),
+    PATCH: jest.fn(),
+    DELETE: jest.fn(),
+    POST: jest.fn(),
+  },
+}))
+
+describe('UsersPage', () => {
+  beforeEach(() => {
+    jest.resetAllMocks()
+  })
+
+  it('renders users and updates role', async () => {
+    ;(apiClient.GET as jest.Mock).mockResolvedValue({
+      data: [{ id: 1, email: 'u1@example.com', role: 'USER' }],
+    })
+    ;(apiClient.PATCH as jest.Mock).mockResolvedValue({ data: {} })
+
+    render(<UsersPage />)
+
+    await waitFor(() => {
+      expect(screen.getByText('u1@example.com')).toBeInTheDocument()
+    })
+
+    fireEvent.change(screen.getByDisplayValue('USER'), {
+      target: { value: 'ADMIN' },
+    })
+
+    await waitFor(() => {
+      expect(apiClient.PATCH).toHaveBeenCalledWith('/users/{id}', {
+        params: { path: { id: 1 } },
+        body: { role: 'ADMIN' },
+      })
+    })
+  })
+
+  it('deletes user', async () => {
+    ;(apiClient.GET as jest.Mock).mockResolvedValue({
+      data: [{ id: 1, email: 'u1@example.com', role: 'USER' }],
+    })
+    ;(apiClient.DELETE as jest.Mock).mockResolvedValue({})
+
+    render(<UsersPage />)
+
+    await waitFor(() => {
+      expect(screen.getByText('u1@example.com')).toBeInTheDocument()
+    })
+
+    fireEvent.click(screen.getByText('Delete'))
+
+    await waitFor(() => {
+      expect(apiClient.DELETE).toHaveBeenCalledWith('/users/{id}', {
+        params: { path: { id: 1 } },
+      })
+      expect(screen.queryByText('u1@example.com')).not.toBeInTheDocument()
+    })
+  })
+
+  it('invites user', async () => {
+    ;(apiClient.GET as jest.Mock).mockResolvedValue({ data: [] })
+    ;(apiClient.POST as jest.Mock).mockResolvedValue({ data: {} })
+
+    render(<UsersPage />)
+
+    fireEvent.change(screen.getByPlaceholderText('Email'), {
+      target: { value: 'new@example.com' },
+    })
+    fireEvent.click(screen.getByText('Invite'))
+
+    await waitFor(() => {
+      expect(apiClient.POST).toHaveBeenCalledWith('/auth/invite', {
+        body: { email: 'new@example.com' },
+      })
+      expect(screen.getByPlaceholderText('Email')).toHaveValue('')
+    })
+  })
+})

--- a/apps/web/src/pages/photos/index.tsx
+++ b/apps/web/src/pages/photos/index.tsx
@@ -1,24 +1,25 @@
-import { useEffect, useState } from 'react';
-import { apiClient } from '../../../lib/api';
+/* eslint-disable react-hooks/exhaustive-deps */
+import { useEffect, useState } from 'react'
+import { apiClient } from '../../../lib/api'
 
 type Photo = {
-  id?: number;
-  mode?: string;
-  uploader_id?: string | null;
-};
+  id?: number
+  mode?: string
+  uploader_id?: string | null
+}
 
 type PageMeta = {
-  page?: number;
-  limit?: number;
-  total?: number;
-};
+  page?: number
+  limit?: number
+  total?: number
+}
 
 export default function PhotosPage() {
-  const [photos, setPhotos] = useState<Photo[]>([]);
-  const [meta, setMeta] = useState<PageMeta>({ page: 1, limit: 10, total: 0 });
-  const [mode, setMode] = useState('');
-  const [uploaderId, setUploaderId] = useState('');
-  const [view, setView] = useState<'table' | 'grid'>('table');
+  const [photos, setPhotos] = useState<Photo[]>([])
+  const [meta, setMeta] = useState<PageMeta>({ page: 1, limit: 10, total: 0 })
+  const [mode, setMode] = useState('')
+  const [uploaderId, setUploaderId] = useState('')
+  const [view, setView] = useState<'table' | 'grid'>('table')
 
   const fetchPhotos = async (page = meta.page, limit = meta.limit) => {
     const { data } = await apiClient.GET('/photos', {
@@ -30,28 +31,28 @@ export default function PhotosPage() {
           uploaderId: uploaderId || undefined,
         },
       },
-    });
+    })
     if (data) {
-      setPhotos(data.items || []);
-      setMeta(data.meta || { page: page, limit: limit, total: 0 });
+      setPhotos(data.items || [])
+      setMeta(data.meta || { page: page, limit: limit, total: 0 })
     }
-  };
+  }
 
   useEffect(() => {
-    fetchPhotos();
-  }, []);
+    fetchPhotos()
+  }, [])
 
-  const totalPages = Math.ceil((meta.total || 0) / (meta.limit || 1)) || 1;
+  const totalPages = Math.ceil((meta.total || 0) / (meta.limit || 1)) || 1
 
   const handleSubmit = (e: React.FormEvent) => {
-    e.preventDefault();
-    fetchPhotos();
-  };
+    e.preventDefault()
+    fetchPhotos()
+  }
 
   const changePage = (newPage: number) => {
-    setMeta((m) => ({ ...m, page: newPage }));
-    fetchPhotos(newPage);
-  };
+    setMeta((m) => ({ ...m, page: newPage }))
+    fetchPhotos(newPage)
+  }
 
   return (
     <div>
@@ -61,7 +62,9 @@ export default function PhotosPage() {
           <input
             type="number"
             value={meta.page}
-            onChange={(e) => setMeta((m) => ({ ...m, page: Number(e.target.value) }))}
+            onChange={(e) =>
+              setMeta((m) => ({ ...m, page: Number(e.target.value) }))
+            }
           />
         </label>
         <label>
@@ -69,7 +72,9 @@ export default function PhotosPage() {
           <input
             type="number"
             value={meta.limit}
-            onChange={(e) => setMeta((m) => ({ ...m, limit: Number(e.target.value) }))}
+            onChange={(e) =>
+              setMeta((m) => ({ ...m, limit: Number(e.target.value) }))
+            }
           />
         </label>
         <label>
@@ -130,7 +135,10 @@ export default function PhotosPage() {
       )}
 
       <div style={{ marginTop: '1rem' }}>
-        <button disabled={meta.page === 1} onClick={() => changePage((meta.page || 1) - 1)}>
+        <button
+          disabled={meta.page === 1}
+          onClick={() => changePage((meta.page || 1) - 1)}
+        >
           Prev
         </button>
         <span>
@@ -144,5 +152,5 @@ export default function PhotosPage() {
         </button>
       </div>
     </div>
-  );
+  )
 }

--- a/apps/web/src/pages/users/index.tsx
+++ b/apps/web/src/pages/users/index.tsx
@@ -1,0 +1,99 @@
+import { useEffect, useState } from 'react'
+import { apiClient } from '../../../lib/api'
+
+type User = {
+  id?: number
+  email?: string
+  role?: string
+}
+
+export default function UsersPage() {
+  const [users, setUsers] = useState<User[]>([])
+  const [inviteEmail, setInviteEmail] = useState('')
+  const [error, setError] = useState<string | null>(null)
+
+  const fetchUsers = async () => {
+    const { data } = await apiClient.GET('/users')
+    if (data) {
+      setUsers(data)
+    }
+  }
+
+  useEffect(() => {
+    fetchUsers()
+  }, [])
+
+  const handleRoleChange = async (id: number, role: string) => {
+    await apiClient.PATCH('/users/{id}', {
+      params: { path: { id } },
+      body: { role },
+    })
+    setUsers((prev) => prev.map((u) => (u.id === id ? { ...u, role } : u)))
+  }
+
+  const handleDelete = async (id: number) => {
+    await apiClient.DELETE('/users/{id}', {
+      params: { path: { id } },
+    })
+    setUsers((prev) => prev.filter((u) => u.id !== id))
+  }
+
+  const handleInvite = async (e: React.FormEvent) => {
+    e.preventDefault()
+    setError(null)
+    const { error: err } = await apiClient.POST('/auth/invite', {
+      body: { email: inviteEmail },
+    })
+    if (err) {
+      setError('Invite failed')
+    } else {
+      setInviteEmail('')
+    }
+  }
+
+  return (
+    <div>
+      <form onSubmit={handleInvite} style={{ marginBottom: '1rem' }}>
+        <input
+          placeholder="Email"
+          value={inviteEmail}
+          onChange={(e) => setInviteEmail(e.target.value)}
+        />
+        <button type="submit">Invite</button>
+      </form>
+      {error && (
+        <div role="alert" style={{ color: 'red' }}>
+          {error}
+        </div>
+      )}
+      <table>
+        <thead>
+          <tr>
+            <th>Email</th>
+            <th>Role</th>
+            <th>Actions</th>
+          </tr>
+        </thead>
+        <tbody>
+          {users.map((u) => (
+            <tr key={u.id}>
+              <td>{u.email}</td>
+              <td>
+                <select
+                  value={u.role}
+                  onChange={(e) => handleRoleChange(u.id!, e.target.value)}
+                >
+                  <option value="ADMIN">ADMIN</option>
+                  <option value="USER">USER</option>
+                </select>
+              </td>
+              <td>
+                <button onClick={() => handleDelete(u.id!)}>Delete</button>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- add users page with role updates, deletion, and invitation form
- cover users page with tests and fix jest config import
- silence exhaustive-deps lint warning on photos list

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_689c8935ed1c832ba757d1eb7341d615