### PR TITLE
feat(web): add photo filters and batch assignment

### DIFF
--- a/apps/web/src/pages/__tests__/photos.test.tsx
+++ b/apps/web/src/pages/__tests__/photos.test.tsx
@@ -1,10 +1,10 @@
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
-import PhotosPage from '../photos';
-import { apiClient } from '../../../lib/api';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import PhotosPage from '../photos'
+import { apiClient } from '../../../lib/api'
 
 jest.mock('../../../lib/api', () => ({
-  apiClient: { GET: jest.fn() },
-}));
+  apiClient: { GET: jest.fn(), POST: jest.fn() },
+}))
 
 describe('PhotosPage', () => {
   it('displays photos and paginates', async () => {
@@ -43,4 +43,80 @@ describe('PhotosPage', () => {
     expect(screen.queryByRole('table')).not.toBeInTheDocument();
     expect(screen.getByTestId('photo')).toHaveTextContent('Photo 2');
   });
+
+  it('submits filters', async () => {
+    ;(apiClient.GET as jest.Mock).mockResolvedValue({ data: { items: [], meta: {} } })
+    render(<PhotosPage />)
+    await waitFor(() => expect(apiClient.GET).toHaveBeenCalled())
+    ;(apiClient.GET as jest.Mock).mockClear()
+
+    fireEvent.change(screen.getByLabelText('From:'), {
+      target: { value: '2024-01-01T00:00' },
+    })
+    fireEvent.change(screen.getByLabelText('To:'), {
+      target: { value: '2024-12-31T23:59' },
+    })
+    fireEvent.change(screen.getByLabelText('Site ID:'), {
+      target: { value: 'site1' },
+    })
+    fireEvent.change(screen.getAllByLabelText('Order ID:')[0], {
+      target: { value: '42' },
+    })
+    fireEvent.change(screen.getByLabelText('Status:'), {
+      target: { value: 'SHARED' },
+    })
+
+    fireEvent.click(screen.getByText('Fetch'))
+
+    await waitFor(() => expect(apiClient.GET).toHaveBeenCalled())
+    expect(apiClient.GET).toHaveBeenCalledWith(
+      '/photos',
+      expect.objectContaining({
+        params: {
+          query: expect.objectContaining({
+            from: '2024-01-01T00:00',
+            to: '2024-12-31T23:59',
+            siteId: 'site1',
+            orderId: '42',
+            status: 'SHARED',
+          }),
+        },
+      }),
+    )
+  })
+
+  it('assigns selected photos', async () => {
+    const resp = {
+      items: [
+        { id: 1, mode: 'MOBILE', uploader_id: 'u1' },
+        { id: 2, mode: 'MOBILE', uploader_id: 'u1' },
+      ],
+      meta: { page: 1, limit: 10, total: 2 },
+    }
+    ;(apiClient.GET as jest.Mock).mockResolvedValue({ data: resp })
+    render(<PhotosPage />)
+    await waitFor(() => screen.getByText('Photo 1'))
+
+    const checkboxes = screen.getAllByRole('checkbox')
+    fireEvent.click(checkboxes[0])
+    fireEvent.click(checkboxes[1])
+    fireEvent.change(screen.getAllByLabelText('Order ID:')[1], {
+      target: { value: '999' },
+    })
+    fireEvent.change(screen.getByLabelText('Calendar Week:'), {
+      target: { value: '2025-W01' },
+    })
+    fireEvent.click(screen.getByText('Assign'))
+
+    expect(apiClient.POST).toHaveBeenCalledWith(
+      '/photos/batch/assign',
+      expect.objectContaining({
+        body: {
+          photoIds: ['1', '2'],
+          orderId: '999',
+          calendarWeek: '2025-W01',
+        },
+      }),
+    )
+  })
 });

--- a/docs/web-tool/requirements.md
+++ b/docs/web-tool/requirements.md
@@ -6,9 +6,10 @@ Hauptnutzergruppen:
 - Plakatierer (optional): Eigene Uploads sichten, Status einsehen.
 
 Kernfunktionen:
-- Galerie mit schneller Filterung (Plakatierer, Woche, Standort, Modus, Qualität, Auftrag, Kunde, Zeitraum, Status).
+- Galerie mit schneller Filterung (Plakatierer, Woche, Standort, Modus, Qualität, Auftrag, Kunde, Zeitraum, Status) sowie spezifischen Parametern `from`, `to`, `orderId`, `status`, `siteId`.
 - Kartenansicht mit Clustering, Bounding-Box-Filter, Standortkorrektur.
 - Bulk-Operationen: Multi-Select, Zuweisen, Ausblenden, Curate-Flag, Re-Matching, Export.
+- Mehrfachauswahl im Grid/Table mit Auftragszuweisung via `POST /photos/batch/assign`.
 - Kundenfreigaben: Links (ablaufbar), Kunden-Login, ZIP- und Excel-Export, PDF-Report, Karten-Sharing.
 - Freigabeverwaltung: bestehende Shares listen, neue Links erzeugen, Widerruf über `DELETE /shares/{id}`; die generierte URL wird nach Erstellung angezeigt.
 - Nutzer-/Rollenverwaltung; Einladungslinks, Passwort-Reset, 2FA (später).


### PR DESCRIPTION
## Summary
- add filter fields (from, to, order, status, site) to photo page
- support selecting photos in grid and table views
- allow batch assignment of photos to an order via POST /photos/batch/assign
- document filters and batch workflow
- test filters and batch assignment

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_689ca1484ff4832bb1f85bd630d0c3c7