### PR TITLE
feat(web): add export jobs page

### DIFF
--- a/apps/web/src/pages/__tests__/exports.test.tsx
+++ b/apps/web/src/pages/__tests__/exports.test.tsx
@@ -1,0 +1,50 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import ExportsPage from '../exports'
+import { apiClient } from '../../../lib/api'
+
+jest.mock('../../../lib/api', () => ({
+  apiClient: { GET: jest.fn(), POST: jest.fn() },
+}))
+
+describe('ExportsPage', () => {
+  beforeEach(() => {
+    jest.resetAllMocks()
+  })
+
+  it('lists exports and shows download link', async () => {
+    ;(apiClient.GET as jest.Mock).mockResolvedValue({
+      data: [{ id: 'e1', status: 'done', url: 'http://example.com' }],
+    })
+
+    render(<ExportsPage />)
+
+    await waitFor(() => {
+      expect(screen.getByText('e1')).toBeInTheDocument()
+    })
+
+    expect(screen.getByText('done')).toBeInTheDocument()
+    expect(screen.getByText('Download')).toHaveAttribute(
+      'href',
+      'http://example.com',
+    )
+  })
+
+  it('triggers export job', async () => {
+    ;(apiClient.GET as jest.Mock).mockResolvedValue({ data: [] })
+    ;(apiClient.POST as jest.Mock).mockResolvedValue({
+      data: { id: 'e2', status: 'queued' },
+    })
+
+    render(<ExportsPage />)
+
+    fireEvent.click(screen.getByText('Start Export'))
+
+    await waitFor(() => {
+      expect(apiClient.POST).toHaveBeenCalledWith('/exports', {})
+    })
+
+    await waitFor(() => {
+      expect(screen.getByText('e2')).toBeInTheDocument()
+    })
+  })
+})

--- a/apps/web/src/pages/exports/index.tsx
+++ b/apps/web/src/pages/exports/index.tsx
@@ -1,0 +1,62 @@
+/* eslint-disable react-hooks/exhaustive-deps */
+import { useEffect, useState } from 'react'
+import { apiClient } from '../../../lib/api'
+
+type ExportJob = {
+  id?: string
+  status?: string
+  url?: string
+}
+
+export default function ExportsPage() {
+  const [jobs, setJobs] = useState<ExportJob[]>([])
+
+  const client = apiClient as unknown as {
+    GET: typeof apiClient.GET
+    POST: typeof apiClient.POST
+  }
+
+  const fetchExports = async () => {
+    const { data } = await client.GET('/exports')
+    if (data) setJobs(data as ExportJob[])
+  }
+
+  useEffect(() => {
+    fetchExports()
+  }, [])
+
+  const triggerExport = async () => {
+    const { data } = await client.POST('/exports', {})
+    if (data) setJobs((prev) => [...prev, data as ExportJob])
+  }
+
+  return (
+    <div>
+      <button onClick={triggerExport}>Start Export</button>
+      <table>
+        <thead>
+          <tr>
+            <th>ID</th>
+            <th>Status</th>
+            <th>Result</th>
+          </tr>
+        </thead>
+        <tbody>
+          {jobs.map((job) => (
+            <tr key={job.id}>
+              <td>{job.id}</td>
+              <td>{job.status}</td>
+              <td>
+                {job.status === 'done' && job.url ? (
+                  <a href={job.url} target="_blank" rel="noopener noreferrer">
+                    Download
+                  </a>
+                ) : null}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}

--- a/docs/web-tool/requirements.md
+++ b/docs/web-tool/requirements.md
@@ -13,6 +13,7 @@ Kernfunktionen:
 - Mehrfachauswahl im Grid/Table mit Auftragszuweisung via `POST /photos/batch/assign`.
 - Kundenfreigaben: Links (ablaufbar), Kunden-Login, ZIP- und Excel-Export, PDF-Report, Karten-Sharing.
 - Freigabeverwaltung: bestehende Shares listen, neue Links erzeugen, Widerruf über `DELETE /shares/{id}`; die generierte URL wird nach Erstellung angezeigt.
+- Export-Workflow: Export-Jobs listen (`GET /exports`), neue Exporte anstoßen (`POST /exports`), Status anzeigen und Download-Link bei abgeschlossenen Jobs (`status=done`).
 - Nutzer-/Rollenverwaltung; Einladungslinks, Passwort-Reset, 2FA (später).
 - Auftragsverwaltung: Aufträge listen, nach Kunde und Status filtern sowie neue Aufträge anlegen.
  - Authentifizierung via Token: Browser speichert das Token und sendet es bei jeder API-Anfrage als `Authorization: Bearer <token>`.


### PR DESCRIPTION
## Summary
- implement Exports page to list jobs and trigger new exports
- show job status with download link when done
- document export workflow

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_689ccd156f70832badb4f43cc42e2d15