### PR TITLE
feat(web): edit photo metadata and enable map drag

### DIFF
--- a/apps/web/src/components/PhotoMap.tsx
+++ b/apps/web/src/components/PhotoMap.tsx
@@ -1,65 +1,73 @@
-import { useEffect, useRef } from 'react';
-import L from 'leaflet';
-import 'leaflet.markercluster';
-import { apiClient } from '../../lib/api';
+import { useEffect, useRef } from 'react'
+import L from 'leaflet'
+import 'leaflet.markercluster'
+import { apiClient } from '../../lib/api'
 
 type Photo = {
-  id: number;
+  id: number
   ad_hoc_spot?: {
-    lat: number;
-    lon: number;
-  };
-};
+    lat: number
+    lon: number
+  }
+}
 
 export default function PhotoMap() {
-  const containerRef = useRef<HTMLDivElement>(null);
+  const containerRef = useRef<HTMLDivElement>(null)
 
   useEffect(() => {
-    if (!containerRef.current) return;
+    if (!containerRef.current) return
 
-    const map = L.map(containerRef.current).setView([0, 0], 2);
-    L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png').addTo(map);
+    const map = L.map(containerRef.current).setView([0, 0], 2)
+    L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png').addTo(map)
 
-    const cluster = L.markerClusterGroup();
-    map.addLayer(cluster);
+    const cluster = L.markerClusterGroup()
+    map.addLayer(cluster)
 
     const fetchPhotos = async () => {
-      const bounds = map.getBounds();
+      const bounds = map.getBounds()
       const bbox = [
         bounds.getSouth(),
         bounds.getWest(),
         bounds.getNorth(),
         bounds.getEast(),
-      ].join(',');
+      ].join(',')
       const { data } = await apiClient.GET('/photos', {
         params: { query: { bbox } },
-      });
-      cluster.clearLayers();
+      })
+      cluster.clearLayers()
       data?.items?.forEach((p: Photo) => {
         if (p.ad_hoc_spot) {
           const marker = L.marker(
             [p.ad_hoc_spot.lat, p.ad_hoc_spot.lon],
             {
+              draggable: true,
               icon: L.divIcon({
                 className: '',
                 html: '<div data-testid="marker"></div>',
               }),
             },
-          );
-          cluster.addLayer(marker);
+          )
+          marker.on('dragend', async (e) => {
+            const { lat, lng } = (e.target as L.Marker).getLatLng()
+            await apiClient.PATCH('/photos/{id}', {
+              params: { path: { id: p.id } },
+              body: { ad_hoc_spot: { lat, lon: lng } },
+            })
+          })
+          cluster.addLayer(marker)
         }
-      });
-    };
+      })
+    }
 
-    fetchPhotos();
-    map.on('moveend', fetchPhotos);
+    fetchPhotos()
+    map.on('moveend', fetchPhotos)
 
     return () => {
-      map.off('moveend', fetchPhotos);
-      map.remove();
-    };
-  }, []);
+      map.off('moveend', fetchPhotos)
+      map.remove()
+    }
+  }, [])
 
-  return <div ref={containerRef} style={{ height: '400px' }} data-testid="photo-map" />;
+  return <div ref={containerRef} style={{ height: '400px' }} data-testid="photo-map" />
 }
 

--- a/apps/web/src/pages/photos/[id].tsx
+++ b/apps/web/src/pages/photos/[id].tsx
@@ -1,0 +1,103 @@
+import { useRouter } from 'next/router'
+import { useEffect, useState } from 'react'
+import { apiClient } from '../../../lib/api'
+
+type Photo = {
+  quality_flag?: string | null
+  note?: string | null
+  mode?: string | null
+  site_id?: string | null
+  device_id?: string | null
+  uploader_id?: string | null
+}
+
+export default function PhotoDetailPage() {
+  const router = useRouter()
+  const { id } = router.query
+  const [photo, setPhoto] = useState<Photo>({})
+
+  useEffect(() => {
+    if (!id) return
+    const fetchPhoto = async () => {
+      const { data } = await apiClient.GET('/photos/{id}', {
+        params: { path: { id: Number(id) } },
+      })
+      if (data) setPhoto(data)
+    }
+    fetchPhoto()
+  }, [id])
+
+  const handleChange = (
+    e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement>,
+  ) => {
+    const { name, value } = e.target
+    setPhoto((p) => ({ ...p, [name]: value }))
+  }
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    if (!id) return
+    await apiClient.PATCH('/photos/{id}', {
+      params: { path: { id: Number(id) } },
+      body: {
+        quality_flag: photo.quality_flag || null,
+        note: photo.note || null,
+        mode: photo.mode || null,
+        site_id: photo.site_id || null,
+        device_id: photo.device_id || null,
+        uploader_id: photo.uploader_id || null,
+      },
+    })
+  }
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <label>
+        Quality Flag:
+        <input
+          name="quality_flag"
+          value={photo.quality_flag || ''}
+          onChange={handleChange}
+        />
+      </label>
+      <label>
+        Note:
+        <textarea
+          name="note"
+          value={photo.note || ''}
+          onChange={handleChange}
+        />
+      </label>
+      <label>
+        Mode:
+        <select name="mode" value={photo.mode || ''} onChange={handleChange}>
+          <option value=""></option>
+          <option value="FIXED_SITE">FIXED_SITE</option>
+          <option value="MOBILE">MOBILE</option>
+        </select>
+      </label>
+      <label>
+        Site ID:
+        <input name="site_id" value={photo.site_id || ''} onChange={handleChange} />
+      </label>
+      <label>
+        Device ID:
+        <input
+          name="device_id"
+          value={photo.device_id || ''}
+          onChange={handleChange}
+        />
+      </label>
+      <label>
+        Uploader ID:
+        <input
+          name="uploader_id"
+          value={photo.uploader_id || ''}
+          onChange={handleChange}
+        />
+      </label>
+      <button type="submit">Save</button>
+    </form>
+  )
+}
+

--- a/docs/web-tool/requirements.md
+++ b/docs/web-tool/requirements.md
@@ -8,7 +8,8 @@ Hauptnutzergruppen:
 Kernfunktionen:
 - Galerie mit schneller Filterung (Plakatierer, Woche, Standort, Modus, Qualität, Auftrag, Kunde, Zeitraum, Status) sowie spezifischen Parametern `from`, `to`, `orderId`, `status`, `siteId`.
 - Kartenansicht mit Leaflet, lädt `/photos?bbox=` abhängig vom Kartenausschnitt,
-  clustert Marker und erlaubt Standortkorrektur.
+  clustert Marker und erlaubt Standortkorrektur per Drag-and-Drop
+  (`PATCH /photos/{id}` aktualisiert die Koordinaten).
 - Bulk-Operationen: Multi-Select, Zuweisen, Ausblenden, Curate-Flag, Re-Matching, Export.
 - Mehrfachauswahl im Grid/Table mit Auftragszuweisung via `POST /photos/batch/assign`.
 - Kundenfreigaben: Links (ablaufbar), Kunden-Login, ZIP- und Excel-Export, PDF-Report, Karten-Sharing.
@@ -16,6 +17,8 @@ Kernfunktionen:
 - Export-Workflow: Export-Jobs listen (`GET /exports`), neue Exporte anstoßen (`POST /exports`), Status anzeigen und Download-Link bei abgeschlossenen Jobs (`status=done`).
 - Nutzer-/Rollenverwaltung; Einladungslinks, Passwort-Reset, 2FA (später).
 - Auftragsverwaltung: Aufträge listen, nach Kunde und Status filtern sowie neue Aufträge anlegen.
+- Foto-Detailseite zur Bearbeitung von Metadaten (`quality_flag`, `note`, ...)
+  über `PATCH /photos/{id}`.
  - Authentifizierung via Token: Browser speichert das Token und sendet es bei jeder API-Anfrage als `Authorization: Bearer <token>`.
    - `AuthContext` verwaltet Loginstatus und Token im Frontend.
    - `AuthGuard` schützt Seiten und leitet nicht authentifizierte Nutzer auf `/login`.


### PR DESCRIPTION
## Summary
- add photo detail page for updating metadata
- allow dragging map markers to patch new coordinates
- document photo editing and draggable markers

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_689cdc7e4260832b9e5ee4e3947fe31c