### PR TITLE
feat(web): add invitation acceptance page

### DIFF
--- a/apps/web/src/pages/__tests__/accept.test.tsx
+++ b/apps/web/src/pages/__tests__/accept.test.tsx
@@ -1,0 +1,58 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import AcceptPage from '../accept/[token]';
+import { apiClient } from '../../../lib/api';
+import { useRouter } from 'next/router';
+
+jest.mock('next/router', () => ({
+  useRouter: jest.fn(),
+}));
+
+jest.mock('../../../lib/api', () => ({
+  apiClient: { POST: jest.fn() },
+}));
+
+const mockedUseRouter = useRouter as jest.Mock;
+
+describe('AcceptPage', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+    mockedUseRouter.mockReturnValue({
+      query: { token: 'tok1' },
+    });
+  });
+
+  it('posts token and password', async () => {
+    (apiClient.POST as jest.Mock).mockResolvedValue({ error: undefined });
+
+    render(<AcceptPage />);
+
+    fireEvent.change(screen.getByPlaceholderText('Password'), {
+      target: { value: 'pw' },
+    });
+    fireEvent.click(screen.getByText('Set Password'));
+
+    await waitFor(() => {
+      expect(apiClient.POST).toHaveBeenCalledWith('/auth/accept', {
+        body: { token: 'tok1', password: 'pw' },
+      });
+      expect(
+        screen.getByText('Password set. You can now log in.'),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it('shows error on failure', async () => {
+    (apiClient.POST as jest.Mock).mockResolvedValue({ error: {} });
+
+    render(<AcceptPage />);
+
+    fireEvent.change(screen.getByPlaceholderText('Password'), {
+      target: { value: 'pw' },
+    });
+    fireEvent.click(screen.getByText('Set Password'));
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toHaveTextContent('Accept failed');
+    });
+  });
+});

--- a/apps/web/src/pages/accept/[token].tsx
+++ b/apps/web/src/pages/accept/[token].tsx
@@ -1,0 +1,43 @@
+import { useRouter } from 'next/router';
+import { useState } from 'react';
+import { apiClient } from '../../../lib/api';
+
+export default function AcceptPage() {
+  const router = useRouter();
+  const { token } = router.query;
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState(false);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError(null);
+    if (!token || Array.isArray(token)) return;
+    const { error: err } = await apiClient.POST('/auth/accept', {
+      body: { token, password },
+    });
+    if (err) {
+      setError('Accept failed');
+    } else {
+      setSuccess(true);
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <input
+        type="password"
+        placeholder="Password"
+        value={password}
+        onChange={(e) => setPassword(e.target.value)}
+      />
+      <button type="submit">Set Password</button>
+      {error && (
+        <div role="alert" style={{ color: 'red' }}>
+          {error}
+        </div>
+      )}
+      {success && <div>Password set. You can now log in.</div>}
+    </form>
+  );
+}

--- a/docs/web-tool/requirements.md
+++ b/docs/web-tool/requirements.md
@@ -31,6 +31,12 @@ Kernfunktionen:
 - Die Galerie lädt die Fotos des Auftrags und ruft für jedes Bild `/public/shares/{token}/photos/{id}` auf.
 - Der Kunde kann einzelne Fotos auswählen und ZIP- (`POST /exports/zip`) oder Excel-Exporte (`POST /exports/excel`) starten.
 
+## Invite-Flow
+- Ein Administrator lädt einen Nutzer über `POST /auth/invite` ein.
+- Der Nutzer erhält einen Link `/accept/{token}`.
+- Auf der Accept-Seite setzt der Nutzer ein neues Passwort; das Frontend sendet `POST /auth/accept` mit Token und Passwort.
+- Nach erfolgreichem Setzen des Passworts kann sich der Nutzer über `/login` anmelden.
+
 UX/Leistung:
 - Flüssige Interaktionen bei großen Datenmengen (Server-seitige Filter/Pagination, Streaming/Infinite Scroll).
 - Tastaturkürzel, Batch-Workflows, Undo.


### PR DESCRIPTION
## Summary
- add accept page for setting password via token
- cover acceptance form with tests
- document invite flow from invite link to password setup

## Testing
- `npm run lint && npm test`


------
https://chatgpt.com/codex/tasks/task_b_689cdfc5dd24832bbb576849cc9ddcda