### PR TITLE
feat(web): add locations management

### DIFF
--- a/apps/web/src/pages/__tests__/locations.test.tsx
+++ b/apps/web/src/pages/__tests__/locations.test.tsx
@@ -1,0 +1,95 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import LocationsPage from '../locations'
+import { apiClient } from '../../../lib/api'
+
+jest.mock('../../../lib/api', () => ({
+  apiClient: { GET: jest.fn(), PATCH: jest.fn() },
+}))
+
+describe('LocationsPage', () => {
+  beforeEach(() => {
+    jest.resetAllMocks()
+  })
+
+  it('lists locations, searches and paginates', async () => {
+    const page1 = {
+      items: [{ id: 1, name: 'Loc1', address: 'A', active: true }],
+      meta: { page: 1, limit: 1, total: 2 },
+    }
+    const page2 = {
+      items: [{ id: 2, name: 'Loc2', address: 'B', active: false }],
+      meta: { page: 2, limit: 1, total: 2 },
+    }
+    ;(apiClient.GET as jest.Mock)
+      .mockResolvedValueOnce({ data: page1 })
+      .mockResolvedValueOnce({ data: page2 })
+      .mockResolvedValue({ data: page1 })
+
+    render(<LocationsPage />)
+
+    await waitFor(() => {
+      expect(screen.getByDisplayValue('Loc1')).toBeInTheDocument()
+    })
+
+    fireEvent.click(screen.getByText('Next'))
+
+    await waitFor(() => {
+      expect(screen.getByDisplayValue('Loc2')).toBeInTheDocument()
+    })
+
+    fireEvent.change(screen.getByPlaceholderText('q'), {
+      target: { value: 'foo' },
+    })
+    fireEvent.change(screen.getByPlaceholderText('near'), {
+      target: { value: '1,2' },
+    })
+    fireEvent.change(screen.getByPlaceholderText('radius_m'), {
+      target: { value: '100' },
+    })
+    fireEvent.click(screen.getByText('Search'))
+
+    await waitFor(() => {
+      expect(apiClient.GET).toHaveBeenLastCalledWith(
+        '/locations',
+        expect.objectContaining({
+          params: {
+            query: expect.objectContaining({
+              q: 'foo',
+              near: '1,2',
+              radius_m: 100,
+            }),
+          },
+        }),
+      )
+    })
+  })
+
+  it('updates location', async () => {
+    ;(apiClient.GET as jest.Mock).mockResolvedValue({
+      data: {
+        items: [{ id: 1, name: 'Old', address: 'A', active: true }],
+        meta: { page: 1, limit: 10, total: 1 },
+      },
+    })
+    ;(apiClient.PATCH as jest.Mock).mockResolvedValue({ data: {} })
+
+    render(<LocationsPage />)
+
+    await waitFor(() => {
+      expect(screen.getByDisplayValue('Old')).toBeInTheDocument()
+    })
+
+    fireEvent.change(screen.getByDisplayValue('Old'), {
+      target: { value: 'New' },
+    })
+    fireEvent.click(screen.getByText('Save'))
+
+    await waitFor(() => {
+      expect(apiClient.PATCH).toHaveBeenCalledWith('/locations/{id}', {
+        params: { path: { id: 1 } },
+        body: { name: 'New', address: 'A', active: true },
+      })
+    })
+  })
+})
+

--- a/apps/web/src/pages/locations/index.tsx
+++ b/apps/web/src/pages/locations/index.tsx
@@ -1,0 +1,168 @@
+import { useEffect, useState } from 'react'
+import { apiClient } from '../../../lib/api'
+
+type Location = {
+  id?: number
+  name?: string
+  address?: string
+  active?: boolean
+}
+
+type PageMeta = {
+  page?: number
+  limit?: number
+  total?: number
+}
+
+export default function LocationsPage() {
+  const [locations, setLocations] = useState<Location[]>([])
+  const [meta, setMeta] = useState<PageMeta>({ page: 1, limit: 10, total: 0 })
+  const [q, setQ] = useState('')
+  const [near, setNear] = useState('')
+  const [radius, setRadius] = useState(50)
+
+  const fetchLocations = async (page = meta.page, limit = meta.limit) => {
+    const { data } = await apiClient.GET('/locations', {
+      params: {
+        query: {
+          q: q || undefined,
+          near: near || undefined,
+          radius_m: radius || undefined,
+          page,
+          limit,
+        },
+      },
+    })
+    if (data) {
+      setLocations(data.items || [])
+      setMeta(data.meta || { page, limit, total: 0 })
+    }
+  }
+
+  useEffect(() => {
+    fetchLocations()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  const handleSearch = (e: React.FormEvent) => {
+    e.preventDefault()
+    setMeta((m) => ({ ...m, page: 1 }))
+    fetchLocations(1)
+  }
+
+  const changePage = (newPage: number) => {
+    setMeta((m) => ({ ...m, page: newPage }))
+    fetchLocations(newPage)
+  }
+
+  const handleFieldChange = (
+    id: number,
+    field: keyof Location,
+    value: string | boolean,
+  ) => {
+    setLocations((prev) =>
+      prev.map((l) => (l.id === id ? { ...l, [field]: value } : l)),
+    )
+  }
+
+  const handleSave = async (loc: Location) => {
+    await apiClient.PATCH('/locations/{id}', {
+      params: { path: { id: loc.id! } },
+      body: {
+        name: loc.name,
+        address: loc.address,
+        active: loc.active,
+      },
+    })
+  }
+
+  const totalPages = Math.ceil((meta.total || 0) / (meta.limit || 1)) || 1
+
+  return (
+    <div>
+      <form onSubmit={handleSearch} style={{ marginBottom: '1rem' }}>
+        <input
+          placeholder="q"
+          value={q}
+          onChange={(e) => setQ(e.target.value)}
+        />
+        <input
+          placeholder="near"
+          value={near}
+          onChange={(e) => setNear(e.target.value)}
+        />
+        <input
+          type="number"
+          placeholder="radius_m"
+          value={radius}
+          onChange={(e) => setRadius(Number(e.target.value))}
+        />
+        <button type="submit">Search</button>
+      </form>
+
+      <table>
+        <thead>
+          <tr>
+            <th>Name</th>
+            <th>Address</th>
+            <th>Active</th>
+            <th>Actions</th>
+          </tr>
+        </thead>
+        <tbody>
+          {locations.map((l) => (
+            <tr key={l.id}>
+              <td>
+                <input
+                  value={l.name || ''}
+                  onChange={(e) =>
+                    handleFieldChange(l.id!, 'name', e.target.value)
+                  }
+                />
+              </td>
+              <td>
+                <input
+                  value={l.address || ''}
+                  onChange={(e) =>
+                    handleFieldChange(l.id!, 'address', e.target.value)
+                  }
+                />
+              </td>
+              <td>
+                <input
+                  type="checkbox"
+                  checked={!!l.active}
+                  onChange={(e) =>
+                    handleFieldChange(l.id!, 'active', e.target.checked)
+                  }
+                />
+              </td>
+              <td>
+                <button onClick={() => handleSave(l)}>Save</button>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+
+      <div style={{ marginTop: '1rem' }}>
+        <button
+          disabled={meta.page === 1}
+          onClick={() => changePage((meta.page || 1) - 1)}
+        >
+          Prev
+        </button>
+        <span>
+          {meta.page} / {totalPages}
+        </span>
+        <button
+          disabled={meta.page === totalPages}
+          onClick={() => changePage((meta.page || 1) + 1)}
+        >
+          Next
+        </button>
+      </div>
+    </div>
+  )
+}
+

--- a/docs/web-tool/requirements.md
+++ b/docs/web-tool/requirements.md
@@ -17,13 +17,14 @@ Kernfunktionen:
 - Export-Workflow: Export-Jobs listen (`GET /exports`), ZIP- und Excel-Exporte anstoßen (`POST /exports/zip`, `POST /exports/excel`), Status via Polling aktualisieren (`GET /exports/{id}`) und Download-Link bei abgeschlossenen Jobs (`status=done`).
 - Nutzer-/Rollenverwaltung; Einladungslinks, Passwort-Reset, 2FA (später).
 - Auftragsverwaltung: Aufträge listen, nach Kunde und Status filtern sowie neue Aufträge anlegen.
+- Standortpflege: Standorte suchen (`q`, `near`, `radius_m`), paginiert listen und Name, Adresse oder Aktivstatus bearbeiten (`PATCH /locations/{id}`).
 - Foto-Detailseite zur Bearbeitung von Metadaten (`quality_flag`, `note`, ...)
-  über `PATCH /photos/{id}`.
- - Authentifizierung via Token: Browser speichert das Token und sendet es bei jeder API-Anfrage als `Authorization: Bearer <token>`.
-   - `AuthContext` verwaltet Loginstatus und Token im Frontend.
-   - `AuthGuard` schützt Seiten und leitet nicht authentifizierte Nutzer auf `/login`.
-   - Logout löscht das Token und navigiert zu `/login`.
- - Navigationsleiste mit Links zu `Photos`, `Users`, `Orders` und `Shares`.
+    über `PATCH /photos/{id}`.
+- Authentifizierung via Token: Browser speichert das Token und sendet es bei jeder API-Anfrage als `Authorization: Bearer <token>`.
+- `AuthContext` verwaltet Loginstatus und Token im Frontend.
+- `AuthGuard` schützt Seiten und leitet nicht authentifizierte Nutzer auf `/login`.
+- Logout löscht das Token und navigiert zu `/login`.
+- Navigationsleiste mit Links zu `Photos`, `Users`, `Orders` und `Shares`.
 - Branding/Wasserzeichen-Policy je Kunde/Share (Agenturkunden i. d. R. ohne Wasserzeichen).
 
 ## Kunden-Flow


### PR DESCRIPTION
## Summary
- add locations page with search, pagination and inline editing
- cover locations listing and updates with tests
- document location maintenance in web-tool requirements

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_689ce3bc8cfc832bbe24988b958178ac