### PR TITLE
feat(web): add registration page

### DIFF
--- a/apps/web/src/pages/__tests__/register.test.tsx
+++ b/apps/web/src/pages/__tests__/register.test.tsx
@@ -1,0 +1,64 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import RegisterPage from '../register'
+import { apiClient } from '../../../lib/api'
+import { useRouter } from 'next/router'
+
+jest.mock('next/router', () => ({
+  useRouter: jest.fn(),
+}))
+
+const mockedUseRouter = useRouter as jest.Mock
+
+describe('RegisterPage', () => {
+  beforeEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  it('redirects to login on successful registration', async () => {
+    const push = jest.fn()
+    mockedUseRouter.mockReturnValue({ push })
+
+    jest
+      .spyOn(apiClient, 'POST')
+      .mockResolvedValue({ data: {} } as unknown as Awaited<
+        ReturnType<typeof apiClient.POST>
+      >)
+
+    render(<RegisterPage />)
+
+    fireEvent.change(screen.getByPlaceholderText('Email'), {
+      target: { value: 'user@example.com' },
+    })
+    fireEvent.change(screen.getByPlaceholderText('Password'), {
+      target: { value: 'pw' },
+    })
+    fireEvent.click(screen.getByText('Register'))
+
+    await waitFor(() => {
+      expect(push).toHaveBeenCalledWith('/login')
+    })
+  })
+
+  it('shows error on failed registration', async () => {
+    mockedUseRouter.mockReturnValue({ push: jest.fn() })
+    jest
+      .spyOn(apiClient, 'POST')
+      .mockResolvedValue({ data: undefined, error: {} } as unknown as Awaited<
+        ReturnType<typeof apiClient.POST>
+      >)
+
+    render(<RegisterPage />)
+
+    fireEvent.change(screen.getByPlaceholderText('Email'), {
+      target: { value: 'user@example.com' },
+    })
+    fireEvent.change(screen.getByPlaceholderText('Password'), {
+      target: { value: 'pw' },
+    })
+    fireEvent.click(screen.getByText('Register'))
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toHaveTextContent('Registration failed')
+    })
+  })
+})

--- a/apps/web/src/pages/register.tsx
+++ b/apps/web/src/pages/register.tsx
@@ -1,0 +1,45 @@
+import { useState } from 'react'
+import { useRouter } from 'next/router'
+import { apiClient } from '../../lib/api'
+
+export default function RegisterPage() {
+  const [email, setEmail] = useState('')
+  const [password, setPassword] = useState('')
+  const [error, setError] = useState<string | null>(null)
+  const router = useRouter()
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    setError(null)
+    const { data } = await apiClient.POST('/auth/register', {
+      body: { email, password },
+    })
+    if (data) {
+      router.push('/login')
+    } else {
+      setError('Registration failed')
+    }
+  }
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <input
+        placeholder="Email"
+        value={email}
+        onChange={(e) => setEmail(e.target.value)}
+      />
+      <input
+        type="password"
+        placeholder="Password"
+        value={password}
+        onChange={(e) => setPassword(e.target.value)}
+      />
+      <button type="submit">Register</button>
+      {error && (
+        <div role="alert" style={{ color: 'red' }}>
+          {error}
+        </div>
+      )}
+    </form>
+  )
+}

--- a/docs/web-tool/requirements.md
+++ b/docs/web-tool/requirements.md
@@ -1,11 +1,13 @@
 # Web-Tool – Anforderungen
 
 Hauptnutzergruppen:
+
 - Verwaltung/Team: Prüfung, Korrektur, Zuordnung, Exporte, Freigaben.
 - Kunden: Einsicht in freigegebene Aufträge, Download, Karten/Excel.
 - Plakatierer (optional): Eigene Uploads sichten, Status einsehen.
 
 Kernfunktionen:
+
 - Galerie mit schneller Filterung (Plakatierer, Woche, Standort, Modus, Qualität, Auftrag, Kunde, Zeitraum, Status) sowie spezifischen Parametern `from`, `to`, `orderId`, `status`, `siteId`.
 - Kartenansicht mit Leaflet, lädt `/photos?bbox=` abhängig vom Kartenausschnitt,
   clustert Marker und erlaubt Standortkorrektur per Drag-and-Drop
@@ -19,31 +21,36 @@ Kernfunktionen:
 - Auftragsverwaltung: Aufträge listen, nach Kunde und Status filtern sowie neue Aufträge anlegen.
 - Standortpflege: Standorte suchen (`q`, `near`, `radius_m`), paginiert listen und Name, Adresse oder Aktivstatus bearbeiten (`PATCH /locations/{id}`).
 - Foto-Detailseite zur Bearbeitung von Metadaten (`quality_flag`, `note`, ...)
-    über `PATCH /photos/{id}`.
+  über `PATCH /photos/{id}`.
 - Authentifizierung via Token: Browser speichert das Token und sendet es bei jeder API-Anfrage als `Authorization: Bearer <token>`.
 - `AuthContext` verwaltet Loginstatus und Token im Frontend.
 - `AuthGuard` schützt Seiten und leitet nicht authentifizierte Nutzer auf `/login`.
 - Logout löscht das Token und navigiert zu `/login`.
- - Navigationsleiste mit Links zu `Photos`, `Users`, `Orders`, `Shares` und `Exports`.
+- Registrierung neuer Nutzer über Formular (`POST /auth/register`), leitet nach erfolgreicher Registrierung zu `/login`.
+- Navigationsleiste mit Links zu `Photos`, `Users`, `Orders`, `Shares` und `Exports`.
 - Branding/Wasserzeichen-Policy je Kunde/Share (Agenturkunden i. d. R. ohne Wasserzeichen).
 
 ## Kunden-Flow
+
 - Kunde öffnet einen Freigabe-Link `/public/{token}`.
 - Die Galerie lädt die Fotos des Auftrags und ruft für jedes Bild `/public/shares/{token}/photos/{id}` auf.
 - Der Kunde kann einzelne Fotos auswählen und ZIP- (`POST /exports/zip`) oder Excel-Exporte (`POST /exports/excel`) starten; der Status wird über Polling von `/exports/{id}` aktualisiert.
 
 ## Invite-Flow
+
 - Ein Administrator lädt einen Nutzer über `POST /auth/invite` ein.
 - Der Nutzer erhält einen Link `/accept/{token}`.
 - Auf der Accept-Seite setzt der Nutzer ein neues Passwort; das Frontend sendet `POST /auth/accept` mit Token und Passwort.
 - Nach erfolgreichem Setzen des Passworts kann sich der Nutzer über `/login` anmelden.
 
 ## Invite-Flow
+
 - Ein Administrator lädt einen Nutzer über `POST /auth/invite` ein.
 - Der Nutzer erhält einen Link `/accept/{token}`.
 - Auf der Accept-Seite setzt der Nutzer ein neues Passwort; das Frontend sendet `POST /auth/accept` mit Token und Passwort.
 - Nach erfolgreichem Setzen des Passworts kann sich der Nutzer über `/login` anmelden.
 
 UX/Leistung:
+
 - Flüssige Interaktionen bei großen Datenmengen (Server-seitige Filter/Pagination, Streaming/Infinite Scroll).
 - Tastaturkürzel, Batch-Workflows, Undo.


### PR DESCRIPTION
## Summary
- add register page with email/password form using POST /auth/register
- redirect to login after successful registration
- document registration flow

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_689cf41ccc3c832bbb1bb6127352a5be