### PR TITLE
feat(web): add order detail page

### DIFF
--- a/apps/web/src/pages/orders/[id].tsx
+++ b/apps/web/src/pages/orders/[id].tsx
@@ -1,0 +1,77 @@
+import { useRouter } from 'next/router'
+import { useEffect, useState } from 'react'
+import { apiClient } from '../../../lib/api'
+
+type Order = {
+  customer_id?: string
+  name?: string
+  status?: string
+}
+
+export default function OrderDetailPage() {
+  const router = useRouter()
+  const { id } = router.query
+  const [order, setOrder] = useState<Order>({})
+
+  useEffect(() => {
+    if (!id) return
+    const fetchOrder = async () => {
+      const { data } = await apiClient.GET('/orders/{id}', {
+        params: { path: { id: Number(id) } },
+      })
+      if (data) setOrder(data)
+    }
+    fetchOrder()
+  }, [id])
+
+  const handleChange = (
+    e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>,
+  ) => {
+    const { name, value } = e.target
+    setOrder((o) => ({ ...o, [name]: value }))
+  }
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    if (!id) return
+    await apiClient.PATCH('/orders/{id}', {
+      params: { path: { id: Number(id) } },
+      body: {
+        customer_id: order.customer_id || '',
+        name: order.name || '',
+        status: order.status || '',
+      },
+    })
+  }
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <label>
+        Customer ID:
+        <input
+          name="customer_id"
+          value={order.customer_id || ''}
+          onChange={handleChange}
+        />
+      </label>
+      <label>
+        Name:
+        <input name="name" value={order.name || ''} onChange={handleChange} />
+      </label>
+      <label>
+        Status:
+        <select
+          name="status"
+          value={order.status || ''}
+          onChange={handleChange}
+        >
+          <option value=""></option>
+          <option value="reserved">reserved</option>
+          <option value="booked">booked</option>
+          <option value="cancelled">cancelled</option>
+        </select>
+      </label>
+      <button type="submit">Save</button>
+    </form>
+  )
+}

--- a/apps/web/src/pages/orders/index.tsx
+++ b/apps/web/src/pages/orders/index.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable react-hooks/exhaustive-deps */
 import { useEffect, useState } from 'react'
+import Link from 'next/link'
 import { apiClient } from '../../../lib/api'
 
 type Order = {
@@ -144,7 +145,11 @@ export default function OrdersPage() {
         <tbody>
           {orders.map((o) => (
             <tr key={o.id}>
-              <td>{o.id}</td>
+              <td>
+                {o.id !== undefined && (
+                  <Link href={`/orders/${o.id}`}>{o.id}</Link>
+                )}
+              </td>
               <td>{o.name}</td>
               <td>{o.status}</td>
               <td>{o.customer_id}</td>

--- a/docs/web-tool/requirements.md
+++ b/docs/web-tool/requirements.md
@@ -18,7 +18,7 @@ Kernfunktionen:
 - Freigabeverwaltung: bestehende Shares paginiert listen (`page`/`limit`), neue Links mit Ablaufdatum (`expires_at`) und Wasserzeichen-Policy (`watermark_policy`) erzeugen, Widerruf über `POST /shares/{id}/revoke`; die generierte URL wird nach Erstellung angezeigt.
 - Export-Workflow: Export-Jobs der aktuellen Sitzung lokal verfolgen, ZIP- und Excel-Exporte anstoßen (`POST /exports/zip`, `POST /exports/excel`), Status via Polling aktualisieren (`GET /exports/{id}`) und Download-Link bei abgeschlossenen Jobs (`status=done`).
 - Nutzer-/Rollenverwaltung; Einladungslinks, Passwort-Reset, 2FA (später).
-- Auftragsverwaltung: Aufträge listen, nach Kunde und Status filtern sowie neue Aufträge anlegen.
+- Auftragsverwaltung: Aufträge listen, nach Kunde und Status filtern, neue Aufträge anlegen sowie Details ansehen und den Status bearbeiten (`GET /orders/{id}`, `PATCH /orders/{id}`).
 - Standortpflege: Standorte suchen (`q`, `near`, `radius_m`), paginiert listen und Name, Adresse oder Aktivstatus bearbeiten (`PATCH /locations/{id}`).
 - Foto-Detailseite zur Bearbeitung von Metadaten (`quality_flag`, `note`, ...)
   über `PATCH /photos/{id}`.


### PR DESCRIPTION
## Summary
- add order detail page to view and edit orders
- link orders list to detail pages
- document order processing requirements

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_689cf86bf828832b9fe64f730e8686cc