### PR TITLE
feat: add role-based auth guard

### DIFF
--- a/apps/web/lib/api-types.ts
+++ b/apps/web/lib/api-types.ts
@@ -137,6 +137,42 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/auth/me": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get current user */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Current user */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["User"];
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/auth/accept": {
         parameters: {
             query?: never;

--- a/apps/web/src/pages/_app.tsx
+++ b/apps/web/src/pages/_app.tsx
@@ -5,14 +5,22 @@ import { AuthProvider, useAuth } from '../context/AuthContext';
 import Layout from '../components/Layout';
 
 export function AuthGuard({ children }: { children: ReactNode }) {
-  const { isAuthenticated } = useAuth();
+  const { isAuthenticated, role } = useAuth();
   const router = useRouter();
 
   useEffect(() => {
+    const adminPaths = ['/users', '/shares', '/locations'];
     if (!isAuthenticated && router.pathname !== '/login') {
       router.replace('/login');
+    } else if (
+      isAuthenticated &&
+      role &&
+      adminPaths.some((p) => router.pathname.startsWith(p)) &&
+      role !== 'ADMIN'
+    ) {
+      router.replace('/photos');
     }
-  }, [isAuthenticated, router]);
+  }, [isAuthenticated, role, router]);
 
   return <>{children}</>;
 }

--- a/docs/web-tool/requirements.md
+++ b/docs/web-tool/requirements.md
@@ -26,6 +26,7 @@ Kernfunktionen:
 - Authentifizierung via Token: Browser speichert das Token und sendet es bei jeder API-Anfrage als `Authorization: Bearer <token>`.
 - `AuthContext` verwaltet Loginstatus und Token im Frontend.
 - `AuthGuard` schützt Seiten und leitet nicht authentifizierte Nutzer auf `/login`.
+- Admin-Seiten (`Users`, `Shares`, `Locations`) sind nur für Nutzer mit `role === 'ADMIN'` zugänglich und leiten sonst auf `/photos` weiter.
 - Logout löscht das Token und navigiert zu `/login`.
 - Registrierung neuer Nutzer über Formular (`POST /auth/register`), leitet nach erfolgreicher Registrierung zu `/login`.
 - Navigationsleiste mit Links zu `Photos`, `Users`, `Orders`, `Shares` und `Exports`.

--- a/packages/contracts/openapi.yaml
+++ b/packages/contracts/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: DokuSuite API
-  version: 0.2.3
+  version: 0.2.4
   description: |
     API für iOS-App, Web-Tool und Integrationen der DokuSuite.
     Zeitzone: Europe/Berlin. Datums-/Zeitangaben sind RFC3339 UTC, mit klarer Interpretation für Woche (ISO-8601 Kalenderwoche).
@@ -85,6 +85,18 @@ paths:
                 $ref: '#/components/schemas/AuthToken'
         '401':
           $ref: '#/components/responses/Unauthorized'
+
+  /auth/me:
+    get:
+      tags: [auth]
+      summary: Get current user
+      responses:
+        '200':
+          description: Current user
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/User'
 
   /auth/accept:
     post:


### PR DESCRIPTION
## Summary
- add `/auth/me` endpoint to API contract
- persist user role in `AuthContext` and guard admin routes
- document role-based navigation

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_689cfed4fad8832bbdb9e9e15e5a12ac