### PR TITLE
Include URLs in public photo listings

### DIFF
--- a/apps/web/lib/api-types.ts
+++ b/apps/web/lib/api-types.ts
@@ -1143,7 +1143,7 @@ export interface paths {
             };
             requestBody?: never;
             responses: {
-                /** @description Photo ids */
+                /** @description Photos with URLs */
                 200: {
                     headers: {
                         [name: string]: unknown;
@@ -1454,6 +1454,10 @@ export interface components {
         };
         PublicPhoto: {
             id?: number;
+            /** Format: uri */
+            thumbnail_url?: string;
+            /** Format: uri */
+            original_url?: string;
         };
         PublicPhotoList: {
             items?: components["schemas"]["PublicPhoto"][];

--- a/apps/web/src/pages/__tests__/public-share.test.tsx
+++ b/apps/web/src/pages/__tests__/public-share.test.tsx
@@ -22,10 +22,14 @@ describe('PublicSharePage', () => {
   })
 
   it('fetches and displays photos', async () => {
-    ;(apiClient.GET as jest.Mock)
-      .mockResolvedValueOnce({ data: { items: [{ id: 1 }, { id: 2 }] } })
-      .mockResolvedValueOnce({ data: { thumbnail_url: 't1', original_url: 'o1' } })
-      .mockResolvedValueOnce({ data: { thumbnail_url: 't2', original_url: 'o2' } })
+    ;(apiClient.GET as jest.Mock).mockResolvedValueOnce({
+      data: {
+        items: [
+          { id: 1, thumbnail_url: 't1', original_url: 'o1' },
+          { id: 2, thumbnail_url: 't2', original_url: 'o2' },
+        ],
+      },
+    })
 
     render(<PublicSharePage />)
 
@@ -33,27 +37,18 @@ describe('PublicSharePage', () => {
       expect(screen.getAllByRole('img')).toHaveLength(2)
     })
 
-    expect(apiClient.GET).toHaveBeenNthCalledWith(
-      1,
-      '/public/shares/{token}/photos',
-      { params: { path: { token: 'tok1' } } }
-    )
-    expect(apiClient.GET).toHaveBeenNthCalledWith(
-      2,
-      '/public/shares/{token}/photos/{id}',
-      { params: { path: { token: 'tok1', id: 1 } } }
-    )
-    expect(apiClient.GET).toHaveBeenNthCalledWith(
-      3,
-      '/public/shares/{token}/photos/{id}',
-      { params: { path: { token: 'tok1', id: 2 } } }
-    )
+    expect(apiClient.GET).toHaveBeenCalledTimes(1)
+    expect(apiClient.GET).toHaveBeenCalledWith('/public/shares/{token}/photos', {
+      params: { path: { token: 'tok1' } },
+    })
   })
 
   it('posts exports for selected photos', async () => {
-    ;(apiClient.GET as jest.Mock)
-      .mockResolvedValueOnce({ data: { items: [{ id: 1 }] } })
-      .mockResolvedValueOnce({ data: { thumbnail_url: 't1', original_url: 'o1' } })
+    ;(apiClient.GET as jest.Mock).mockResolvedValueOnce({
+      data: {
+        items: [{ id: 1, thumbnail_url: 't1', original_url: 'o1' }],
+      },
+    })
 
     render(<PublicSharePage />)
 
@@ -61,11 +56,10 @@ describe('PublicSharePage', () => {
       expect(screen.getByRole('img')).toBeInTheDocument()
     })
 
-    expect(apiClient.GET).toHaveBeenNthCalledWith(
-      1,
-      '/public/shares/{token}/photos',
-      { params: { path: { token: 'tok1' } } }
-    )
+    expect(apiClient.GET).toHaveBeenCalledTimes(1)
+    expect(apiClient.GET).toHaveBeenCalledWith('/public/shares/{token}/photos', {
+      params: { path: { token: 'tok1' } },
+    })
 
     fireEvent.click(screen.getByRole('checkbox'))
     fireEvent.click(screen.getByText('Download ZIP'))

--- a/apps/web/src/pages/public/[token]/index.tsx
+++ b/apps/web/src/pages/public/[token]/index.tsx
@@ -20,15 +20,7 @@ export default function PublicSharePage() {
       const list = await apiClient.GET('/public/shares/{token}/photos', {
         params: { path: { token } },
       })
-      const items = list.data?.items || []
-      const results: Photo[] = []
-      for (const p of items) {
-        const { data } = await apiClient.GET('/public/shares/{token}/photos/{id}', {
-          params: { path: { token, id: p.id! } },
-        })
-        results.push({ id: p.id!, ...data })
-      }
-      setPhotos(results)
+      setPhotos((list.data?.items as Photo[]) || [])
     }
     load()
   }, [token])

--- a/docs/web-tool/requirements.md
+++ b/docs/web-tool/requirements.md
@@ -35,7 +35,7 @@ Kernfunktionen:
 ## Kunden-Flow
 
 - Kunde öffnet einen Freigabe-Link `/public/{token}`.
-- Die Galerie lädt die Foto-IDs über `/public/shares/{token}/photos` und ruft für jedes Bild `/public/shares/{token}/photos/{id}` auf.
+- Die Galerie lädt die Fotos inklusive URLs direkt über `/public/shares/{token}/photos`; keine Einzelrequests pro Bild.
 - Der Kunde kann einzelne Fotos auswählen und ZIP- (`POST /exports/zip`) oder Excel-Exporte (`POST /exports/excel`) starten; der Status wird über Polling von `/exports/{id}` aktualisiert.
 
 ## Invite-Flow

--- a/packages/contracts/openapi.yaml
+++ b/packages/contracts/openapi.yaml
@@ -552,7 +552,7 @@ paths:
           schema: { type: string }
       responses:
         '200':
-          description: Photo ids
+          description: Photos with URLs
           content:
             application/json:
               schema: { $ref: '#/components/schemas/PublicPhotoList' }
@@ -814,6 +814,8 @@ components:
       type: object
       properties:
         id: { type: integer }
+        thumbnail_url: { type: string, format: uri }
+        original_url: { type: string, format: uri }
     PublicPhotoList:
       type: object
       properties:


### PR DESCRIPTION
## Summary
- extend PublicPhoto schema to expose thumbnail and original URLs
- load public share photos in a single request and adjust tests
- update docs to reflect removal of per-photo requests

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_689d02d29dec832b9cb4bd6e48c4c5c7