### PR TITLE
Add PDF export option and polling support

### DIFF
--- a/apps/web/src/pages/__tests__/exports.test.tsx
+++ b/apps/web/src/pages/__tests__/exports.test.tsx
@@ -74,4 +74,45 @@ describe('ExportsPage', () => {
     expect(apiClient.GET).not.toHaveBeenCalled()
     jest.useRealTimers()
   })
+
+  it('triggers PDF export job and polls until done', async () => {
+    jest.useFakeTimers()
+    ;(apiClient.GET as jest.Mock).mockResolvedValue({
+      data: { id: 'e4', status: 'done', url: 'http://example.com/pdf' },
+    })
+    ;(apiClient.POST as jest.Mock).mockResolvedValue({
+      data: { id: 'e4', status: 'queued' },
+    })
+
+    render(<ExportsPage />)
+
+    fireEvent.click(screen.getByText('Start PDF Export'))
+
+    await waitFor(() => {
+      expect(apiClient.POST).toHaveBeenCalledWith('/exports/pdf', {})
+    })
+
+    await waitFor(() => {
+      expect(screen.getByText('e4')).toBeInTheDocument()
+    })
+
+    expect(apiClient.GET).not.toHaveBeenCalled()
+
+    await act(async () => {
+      jest.advanceTimersByTime(2000)
+      await Promise.resolve()
+    })
+
+    await waitFor(() => {
+      expect(apiClient.GET).toHaveBeenCalledWith('/exports/{id}', {
+        params: { path: { id: 'e4' } },
+      })
+      expect(screen.getByText('done')).toBeInTheDocument()
+    })
+    expect(screen.getByText('Download')).toHaveAttribute(
+      'href',
+      'http://example.com/pdf',
+    )
+    jest.useRealTimers()
+  })
 })

--- a/apps/web/src/pages/exports/index.tsx
+++ b/apps/web/src/pages/exports/index.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable react-hooks/exhaustive-deps */
 import { useEffect, useState } from 'react'
 import { apiClient } from '../../../lib/api'
 
@@ -26,6 +25,11 @@ export default function ExportsPage() {
     if (data) setJobs((prev) => [...prev, data as ExportJob])
   }
 
+  const triggerPdfExport = async () => {
+    const { data } = await client.POST('/exports/pdf', {})
+    if (data) setJobs((prev) => [...prev, data as ExportJob])
+  }
+
   useEffect(() => {
     const pending = jobs.filter((j) => j.status !== 'done')
     if (pending.length === 0) return
@@ -44,12 +48,13 @@ export default function ExportsPage() {
     }, 2000)
 
     return () => clearInterval(interval)
-  }, [jobs])
+  }, [jobs, client])
 
   return (
     <div>
       <button onClick={triggerZipExport}>Start ZIP Export</button>
       <button onClick={triggerExcelExport}>Start Excel Export</button>
+      <button onClick={triggerPdfExport}>Start PDF Export</button>
       <table>
         <thead>
           <tr>

--- a/docs/web-tool/requirements.md
+++ b/docs/web-tool/requirements.md
@@ -36,8 +36,8 @@ Kernfunktionen:
 
 - Kunde öffnet einen Freigabe-Link `/public/{token}`.
 - Die Galerie lädt die Fotos inklusive URLs direkt über `/public/shares/{token}/photos`; keine Einzelrequests pro Bild.
-- Der Kunde kann einzelne Fotos auswählen und ZIP- (`POST /exports/zip`) oder Excel-Exporte (`POST /exports/excel`) starten; der Status wird über Polling von `/exports/{id}` aktualisiert.
-- Der Kunde kann zusätzlich einen PDF-Report (`POST /exports/pdf`) auslösen und eine Kartenansicht aufrufen, die Fotos abhängig vom Kartenausschnitt über `/public/shares/{token}/photos?bbox` lädt.
+- Der Kunde kann einzelne Fotos auswählen und ZIP-, Excel- oder PDF-Exporte (`POST /exports/zip`, `POST /exports/excel`, `POST /exports/pdf`) starten; der Status wird über Polling von `/exports/{id}` aktualisiert.
+- Zusätzlich kann der Kunde eine Kartenansicht aufrufen, die Fotos abhängig vom Kartenausschnitt über `/public/shares/{token}/photos?bbox` lädt.
 
 ## Invite-Flow
 


### PR DESCRIPTION
## Summary
- add PDF export trigger button and polling
- test PDF export workflow and polling
- document PDF exports in web-tool requirements

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_689da22252d0832b893bc897faf6b9bb