### PR TITLE
feat(web): implement infinite scroll for photos page

### DIFF
--- a/docs/web-tool/requirements.md
+++ b/docs/web-tool/requirements.md
@@ -8,7 +8,7 @@ Hauptnutzergruppen:
 
 Kernfunktionen:
 
-- Galerie mit schneller Filterung (Plakatierer, Woche, Standort, Modus, Qualität, Auftrag, Kunde, Zeitraum, Status) sowie spezifischen Parametern `from`, `to`, `orderId`, `status`, `siteId`.
+- Galerie mit schneller Filterung (Plakatierer, Woche, Standort, Modus, Qualität, Auftrag, Kunde, Zeitraum, Status) sowie spezifischen Parametern `from`, `to`, `orderId`, `status`, `siteId`. Weitere Seiten werden beim Scrollen automatisch über einen `IntersectionObserver` nachgeladen (`page`/`limit`-basiertes Infinite Scroll).
 - Kartenansicht mit Leaflet, lädt `/photos?bbox=` abhängig vom Kartenausschnitt,
   clustert Marker und erlaubt Standortkorrektur per Drag-and-Drop
   (`PATCH /photos/{id}` aktualisiert die Koordinaten).


### PR DESCRIPTION
## Summary
- load additional photo pages automatically via IntersectionObserver
- test infinite scrolling behavior on the photos page
- document infinite scrolling requirement for web tool

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_689dbff7ea80832b8e8536002b821085