### PR TITLE
feat(web): add ArrowLeft page navigation for photos

### DIFF
--- a/apps/web/src/pages/__tests__/photos.test.tsx
+++ b/apps/web/src/pages/__tests__/photos.test.tsx
@@ -346,6 +346,45 @@ describe('PhotosPage', () => {
     await waitFor(() => expect(undoFn).toHaveBeenCalled())
   })
 
+  it('changes page with ArrowLeft', async () => {
+    jest.clearAllMocks()
+    const page1 = {
+      items: [{ id: 1, mode: 'MOBILE', uploader_id: 'u1' }],
+      meta: { page: 1, limit: 1, total: 2 },
+    }
+    const page2 = {
+      items: [{ id: 2, mode: 'FIXED_SITE', uploader_id: 'u2' }],
+      meta: { page: 2, limit: 1, total: 2 },
+    }
+    ;(apiClient.GET as jest.Mock)
+      .mockResolvedValueOnce({ data: page1 })
+      .mockResolvedValueOnce({ data: page2 })
+      .mockResolvedValueOnce({ data: page1 })
+
+    render(<PhotosPage />)
+
+    await waitFor(() =>
+      expect(screen.getByText('Photo 1')).toBeInTheDocument(),
+    )
+
+    fireEvent.keyDown(window, { key: 'ArrowRight', keyCode: 39, which: 39 })
+
+    await waitFor(() =>
+      expect(screen.getByText('Photo 2')).toBeInTheDocument(),
+    )
+
+    fireEvent.keyDown(window, { key: 'ArrowLeft', keyCode: 37, which: 37 })
+
+    await waitFor(() =>
+      expect(apiClient.GET).toHaveBeenLastCalledWith(
+        '/photos',
+        expect.objectContaining({
+          params: { query: expect.objectContaining({ page: 1 }) },
+        }),
+      ),
+    )
+  })
+
   it('hides selected photos', async () => {
     jest.clearAllMocks()
     ;(apiClient.GET as jest.Mock).mockResolvedValue({

--- a/apps/web/src/pages/photos/index.tsx
+++ b/apps/web/src/pages/photos/index.tsx
@@ -184,6 +184,8 @@ export default function PhotosPage() {
     const handler = (e: KeyboardEvent) => {
       if (e.key === 'ArrowRight') {
         if (meta.page! < totalPages) changePage((meta.page || 1) + 1)
+      } else if (e.key === 'ArrowLeft') {
+        if (meta.page! > 1) changePage((meta.page || 1) - 1)
       } else if (e.key.toLowerCase() === 'a') {
         setSelected((prev) =>
           prev.length === photos.length ? [] : photos.map((p) => p.id!),


### PR DESCRIPTION
## Summary
- handle `ArrowLeft` in photos page to go to previous page
- add test ensuring `ArrowLeft` triggers page change

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_689dd3fe0f14832bb5b6f3e80a9617e7