### PR TITLE
feat(auth): allow public routes in AuthGuard

### DIFF
--- a/apps/web/src/pages/__tests__/login.test.tsx
+++ b/apps/web/src/pages/__tests__/login.test.tsx
@@ -152,6 +152,30 @@ describe('LoginPage', () => {
       global.fetch = originalFetch;
     });
 
+    it('does not redirect unauthenticated users on public routes', async () => {
+      const replace = jest.fn();
+      mockedUseRouter.mockReturnValue({
+        pathname: '/public/info',
+        replace,
+        push: jest.fn(),
+        prefetch: jest.fn(),
+        events: { on: jest.fn(), off: jest.fn() },
+        beforePopState: jest.fn(),
+      });
+
+      render(
+        <AuthProvider>
+          <AuthGuard>
+            <div>public</div>
+          </AuthGuard>
+        </AuthProvider>,
+      );
+
+      await waitFor(() => {
+        expect(replace).not.toHaveBeenCalled();
+      });
+    });
+
     it('redirects unauthenticated users to /login', async () => {
       const replace = jest.fn();
       mockedUseRouter.mockReturnValue({

--- a/apps/web/src/pages/_app.tsx
+++ b/apps/web/src/pages/_app.tsx
@@ -4,13 +4,27 @@ import { useEffect, ReactNode } from 'react';
 import { AuthProvider, useAuth } from '../context/AuthContext';
 import Layout from '../components/Layout';
 
+const publicPaths = [
+  '/login',
+  '/register',
+  '/forgot-password',
+  '/reset',
+  '/accept',
+  '/public',
+  '/2fa/verify',
+];
+
 export function AuthGuard({ children }: { children: ReactNode }) {
   const { isAuthenticated, role } = useAuth();
   const router = useRouter();
 
   useEffect(() => {
     const adminPaths = ['/users', '/shares', '/locations'];
-    if (!isAuthenticated && router.pathname !== '/login') {
+    const isPublicPath = publicPaths.some((p) =>
+      router.pathname.startsWith(p),
+    );
+
+    if (!isAuthenticated && !isPublicPath) {
       router.replace('/login');
     } else if (
       isAuthenticated &&

--- a/docs/web-tool/requirements.md
+++ b/docs/web-tool/requirements.md
@@ -26,6 +26,7 @@ Kernfunktionen:
 - Authentifizierung via Token: Browser speichert das Token und sendet es bei jeder API-Anfrage als `Authorization: Bearer <token>`.
 - `AuthContext` verwaltet Loginstatus und Token im Frontend.
 - `AuthGuard` schützt Seiten und leitet nicht authentifizierte Nutzer auf `/login`.
+- Öffentliche Seiten ohne Login: `/login`, `/register`, `/forgot-password`, `/reset`, `/accept`, `/public`, `/2fa/verify`.
 - Admin-Seiten (`Users`, `Shares`, `Locations`) sind nur für Nutzer mit `role === 'ADMIN'` zugänglich und leiten sonst auf `/photos` weiter.
 - Logout löscht das Token und navigiert zu `/login`.
 - Registrierung neuer Nutzer über Formular (`POST /auth/register`), leitet nach erfolgreicher Registrierung zu `/login`.


### PR DESCRIPTION
## Summary
- allow unauthenticated access to selected public routes
- test AuthGuard public route handling
- document publicly accessible pages

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_689df6bed7c4832bb74c2be62db2c5d6