### PR TITLE
feat(web): redirect to gallery after login

### DIFF
--- a/apps/web/src/pages/__tests__/login.test.tsx
+++ b/apps/web/src/pages/__tests__/login.test.tsx
@@ -13,10 +13,12 @@ jest.mock('next/router', () => ({
 const mockedUseRouter = useRouter as jest.Mock;
 
 let store: Record<string, string> = {};
+let replace: jest.Mock;
 
 describe('LoginPage', () => {
   beforeEach(() => {
     store = {};
+    replace = jest.fn();
     Object.defineProperty(window, 'localStorage', {
       value: {
         setItem: jest.fn((key, value) => {
@@ -31,7 +33,7 @@ describe('LoginPage', () => {
     });
     mockedUseRouter.mockReturnValue({
       pathname: '/login',
-      replace: jest.fn(),
+      replace,
       push: jest.fn(),
       prefetch: jest.fn(),
       events: { on: jest.fn(), off: jest.fn() },
@@ -46,7 +48,7 @@ describe('LoginPage', () => {
     jest.restoreAllMocks();
   });
 
-  it('stores token on successful login', async () => {
+  it('stores token and redirects on successful login', async () => {
     jest.spyOn(apiClient, 'POST').mockResolvedValue(
       {
         data: {
@@ -70,6 +72,7 @@ describe('LoginPage', () => {
 
     await waitFor(() => {
       expect(window.localStorage.setItem).toHaveBeenCalledWith('token', 'token123');
+      expect(replace).toHaveBeenCalledWith('/photos');
     });
   });
 

--- a/apps/web/src/pages/login.tsx
+++ b/apps/web/src/pages/login.tsx
@@ -18,6 +18,7 @@ export default function LoginPage() {
     });
     if (data?.access_token) {
       login(data.access_token);
+      router.replace('/photos');
     } else if (data?.challenge_token) {
       setChallenge(data.challenge_token);
       router.push('/2fa/verify');

--- a/docs/web-tool/requirements.md
+++ b/docs/web-tool/requirements.md
@@ -33,6 +33,11 @@ Kernfunktionen:
 - Navigationsleiste nur für eingeloggte Nutzer mit Links zu `Photos`, `Users`, `Orders`, `Shares` und `Exports`.
 - Branding/Wasserzeichen-Policy je Kunde/Share (Agenturkunden i. d. R. ohne Wasserzeichen).
 
+## Login-Flow
+
+- Nutzer meldet sich auf `/login` mit E-Mail und Passwort an.
+- Bei erfolgreicher Anmeldung speichert das Frontend das Token und leitet automatisch zur Galerie `/photos` weiter.
+
 ## Kunden-Flow
 
 - Kunde öffnet einen Freigabe-Link `/public/{token}`.


### PR DESCRIPTION
## Summary
- navigate to photos gallery after successful login
- verify login redirect in tests
- document login redirect in requirements

## Testing
- `npm run lint`
- `npm test src/pages/__tests__/login.test.tsx`


------
https://chatgpt.com/codex/tasks/task_b_689dfa8d56b0832b8c70c54bb0821fb4