### PR TITLE
Handle expired sessions

### DIFF
--- a/apps/web/lib/api.ts
+++ b/apps/web/lib/api.ts
@@ -15,7 +15,14 @@ export const authFetch: typeof fetch = async (input, init = {}) => {
   if (token) {
     headers.set('Authorization', `Bearer ${token}`);
   }
-  return fetch(input, { ...init, headers });
+  const response = await fetch(input, { ...init, headers });
+  if (response.status === 401) {
+    clearAuthToken();
+    if (typeof window !== 'undefined') {
+      window.location.assign('/login');
+    }
+  }
+  return response;
 };
 
 export const apiClient = createClient<paths>({

--- a/apps/web/src/pages/__tests__/login.test.tsx
+++ b/apps/web/src/pages/__tests__/login.test.tsx
@@ -155,6 +155,20 @@ describe('LoginPage', () => {
       global.fetch = originalFetch;
     });
 
+    it('clears token and redirects to login on 401 responses', async () => {
+      setAuthToken('token123');
+
+      const fetchMock = jest.fn().mockResolvedValue({ status: 401 });
+      const originalFetch = global.fetch;
+      // @ts-expect-error replace fetch for test
+      global.fetch = fetchMock;
+
+      await authFetch('/api/photos');
+      expect(window.localStorage.removeItem).toHaveBeenCalledWith('token');
+
+      global.fetch = originalFetch;
+    });
+
     it('does not redirect unauthenticated users on public routes', async () => {
       const replace = jest.fn();
       mockedUseRouter.mockReturnValue({

--- a/docs/web-tool/requirements.md
+++ b/docs/web-tool/requirements.md
@@ -29,6 +29,7 @@ Kernfunktionen:
 - Öffentliche Seiten ohne Login: `/login`, `/register`, `/forgot-password`, `/reset`, `/accept`, `/public`, `/2fa/verify`.
 - Admin-Seiten (`Users`, `Shares`, `Locations`) sind nur für Nutzer mit `role === 'ADMIN'` zugänglich und leiten sonst auf `/photos` weiter.
 - Logout löscht das Token und navigiert zu `/login`.
+- Bei abgelaufener Sitzung (HTTP 401) löscht das Frontend das Token und leitet automatisch auf `/login` weiter.
 - Registrierung neuer Nutzer über Formular (`POST /auth/register`), leitet nach erfolgreicher Registrierung zu `/login`.
 - Navigationsleiste nur für eingeloggte Nutzer mit Links zu `Photos`, `Users`, `Orders`, `Shares` und `Exports`.
 - Branding/Wasserzeichen-Policy je Kunde/Share (Agenturkunden i. d. R. ohne Wasserzeichen).


### PR DESCRIPTION
## Summary
- clear auth token and redirect to login when 401 responses occur
- test 401 handling during login
- document session expiration handling in web tool requirements

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_689e02935100832bb50df9bc0f2a8e92