### PR TITLE
feat(web): add modern layout styling

### DIFF
--- a/apps/web/src/components/Layout.tsx
+++ b/apps/web/src/components/Layout.tsx
@@ -15,18 +15,22 @@ export default function Layout({ children }: { children: ReactNode }) {
   const showNav = isAuthenticated && router.pathname !== '/login';
 
   return (
-    <div>
+    <div className="app-container">
       {showNav && (
-        <nav>
-          <Link href="/photos">Photos</Link> |{' '}
-          <Link href="/users">Users</Link> |{' '}
-          <Link href="/orders">Orders</Link> |{' '}
-          <Link href="/shares">Shares</Link> |{' '}
-          <Link href="/exports">Exports</Link> |{' '}
-          <button onClick={handleLogout}>Logout</button>
+        <nav className="navbar">
+          <div className="nav-links">
+            <Link href="/photos">Photos</Link>
+            <Link href="/users">Users</Link>
+            <Link href="/orders">Orders</Link>
+            <Link href="/shares">Shares</Link>
+            <Link href="/exports">Exports</Link>
+          </div>
+          <button className="logout-button" onClick={handleLogout}>
+            Logout
+          </button>
         </nav>
       )}
-      {children}
+      <main className="main-content">{children}</main>
     </div>
   );
 }

--- a/apps/web/src/pages/_app.tsx
+++ b/apps/web/src/pages/_app.tsx
@@ -3,6 +3,7 @@ import { useRouter } from 'next/router';
 import { useEffect, ReactNode } from 'react';
 import { AuthProvider, useAuth } from '../context/AuthContext';
 import Layout from '../components/Layout';
+import '../styles/globals.css';
 
 const publicPaths = [
   '/login',

--- a/apps/web/src/styles/globals.css
+++ b/apps/web/src/styles/globals.css
@@ -1,0 +1,63 @@
+:root {
+  --color-bg: #f9fafb;
+  --color-nav-bg: #111827;
+  --color-nav-text: #f9fafb;
+}
+
+body {
+  margin: 0;
+  background: var(--color-bg);
+  color: #111827;
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto,
+    'Helvetica Neue', Arial, 'Noto Sans', sans-serif;
+}
+
+.app-container {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+.navbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  background-color: var(--color-nav-bg);
+  padding: 0.75rem 1.5rem;
+}
+
+.nav-links a {
+  margin-right: 1rem;
+  color: var(--color-nav-text);
+  text-decoration: none;
+  font-weight: 500;
+}
+
+.nav-links a:last-child {
+  margin-right: 0;
+}
+
+.nav-links a:hover {
+  text-decoration: underline;
+}
+
+.logout-button {
+  background: transparent;
+  border: 1px solid var(--color-nav-text);
+  color: var(--color-nav-text);
+  padding: 0.25rem 0.75rem;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.logout-button:hover {
+  background-color: var(--color-nav-text);
+  color: var(--color-nav-bg);
+}
+
+.main-content {
+  flex: 1;
+  max-width: 1200px;
+  margin: 1.5rem auto;
+  padding: 0 1rem;
+}


### PR DESCRIPTION
## Summary
- add global stylesheet for consistent modern look
- redesign layout with flex-based navigation bar and content container

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_689e079b5d88832b9ccf32b5ed1c0e0b