### PR TITLE
feat: add customer management

### DIFF
--- a/apps/web/lib/api-types.ts
+++ b/apps/web/lib/api-types.ts
@@ -1030,6 +1030,133 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/customers": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List customers */
+        get: {
+            parameters: {
+                query?: {
+                    page?: components["parameters"]["page"];
+                    limit?: components["parameters"]["limit"];
+                };
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["Page_Customer_"];
+                    };
+                };
+            };
+        };
+        put?: never;
+        /** Create customer */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": components["schemas"]["CustomerCreate"];
+                };
+            };
+            responses: {
+                /** @description Created */
+                201: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["Customer"];
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/customers/{id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        /** Delete customer */
+        delete: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: components["parameters"]["id"];
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description No Content */
+                204: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                404: components["responses"]["NotFound"];
+            };
+        };
+        options?: never;
+        head?: never;
+        /** Update customer */
+        patch: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: components["parameters"]["id"];
+                };
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": components["schemas"]["CustomerUpdate"];
+                };
+            };
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["Customer"];
+                    };
+                };
+                404: components["responses"]["NotFound"];
+            };
+        };
+        trace?: never;
+    };
     "/orders": {
         parameters: {
             query?: never;
@@ -1590,6 +1717,10 @@ export interface components {
             items?: components["schemas"]["Share"][];
             meta?: components["schemas"]["PageMeta"];
         };
+        Page_Customer_: {
+            items?: components["schemas"]["Customer"][];
+            meta?: components["schemas"]["PageMeta"];
+        };
         GeoPoint: {
             lat?: number;
             lon?: number;
@@ -1679,6 +1810,22 @@ export interface components {
             site_id?: string | null;
             device_id?: string | null;
             uploader_id?: string | null;
+        };
+        CustomerCreate: {
+            name: string;
+            watermark_policy?: components["schemas"]["WatermarkPolicy"];
+            watermark_text?: string | null;
+        };
+        CustomerUpdate: {
+            name?: string | null;
+            watermark_policy?: components["schemas"]["WatermarkPolicy"];
+            watermark_text?: string | null;
+        };
+        Customer: {
+            id?: number;
+            name?: string;
+            watermark_policy?: components["schemas"]["WatermarkPolicy"];
+            watermark_text?: string | null;
         };
         OrderCreate: {
             customer_id: string;

--- a/apps/web/src/pages/__tests__/customers.test.tsx
+++ b/apps/web/src/pages/__tests__/customers.test.tsx
@@ -1,0 +1,135 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import CustomersPage from '../customers'
+import { apiClient } from '../../../lib/api'
+
+jest.mock('../../../lib/api', () => ({
+  apiClient: {
+    GET: jest.fn(),
+    POST: jest.fn(),
+    PATCH: jest.fn(),
+    DELETE: jest.fn(),
+  },
+}))
+
+describe('CustomersPage', () => {
+  beforeEach(() => {
+    jest.resetAllMocks()
+  })
+
+  it('lists customers and paginates', async () => {
+    const page1 = {
+      items: [
+        { id: 1, name: 'c1', watermark_policy: 'none', watermark_text: null },
+      ],
+      meta: { page: 1, limit: 1, total: 2 },
+    }
+    const page2 = {
+      items: [
+        { id: 2, name: 'c2', watermark_policy: 'default', watermark_text: 'w' },
+      ],
+      meta: { page: 2, limit: 1, total: 2 },
+    }
+    ;(apiClient.GET as jest.Mock)
+      .mockResolvedValueOnce({ data: page1 })
+      .mockResolvedValueOnce({ data: page2 })
+      .mockResolvedValue({ data: page1 })
+
+    render(<CustomersPage />)
+
+    await waitFor(() => {
+      expect(screen.getByDisplayValue('c1')).toBeInTheDocument()
+    })
+
+    fireEvent.click(screen.getByText('Next'))
+
+    await waitFor(() => {
+      expect(screen.getByDisplayValue('c2')).toBeInTheDocument()
+    })
+  })
+
+  it('creates customer', async () => {
+    ;(apiClient.GET as jest.Mock).mockResolvedValue({
+      data: { items: [], meta: { page: 1, limit: 10, total: 0 } },
+    })
+    ;(apiClient.POST as jest.Mock).mockResolvedValue({ data: { id: 1 } })
+
+    render(<CustomersPage />)
+
+    fireEvent.change(screen.getByPlaceholderText('Name'), {
+      target: { value: 'Cust' },
+    })
+    fireEvent.change(screen.getByDisplayValue('none'), {
+      target: { value: 'default' },
+    })
+    fireEvent.change(screen.getByPlaceholderText('Watermark Text'), {
+      target: { value: 'txt' },
+    })
+    fireEvent.click(screen.getByText('Create'))
+
+    await waitFor(() => {
+      expect(apiClient.POST).toHaveBeenCalledWith('/customers', {
+        body: {
+          name: 'Cust',
+          watermark_policy: 'default',
+          watermark_text: 'txt',
+        },
+      })
+    })
+  })
+
+  it('updates customer', async () => {
+    const page = {
+      items: [
+        { id: 1, name: 'Cust1', watermark_policy: 'none', watermark_text: null },
+      ],
+      meta: { page: 1, limit: 10, total: 1 },
+    }
+    ;(apiClient.GET as jest.Mock).mockResolvedValue({ data: page })
+
+    render(<CustomersPage />)
+
+    await waitFor(() => expect(screen.getByDisplayValue('Cust1')).toBeInTheDocument())
+
+    fireEvent.change(screen.getByDisplayValue('Cust1'), {
+      target: { value: 'Cust1b' },
+    })
+    fireEvent.click(screen.getByText('Save'))
+
+    await waitFor(() => {
+      expect(apiClient.PATCH).toHaveBeenCalledWith(
+        '/customers/{id}',
+        expect.objectContaining({
+          params: { path: { id: 1 } },
+          body: {
+            name: 'Cust1b',
+            watermark_policy: 'none',
+            watermark_text: null,
+          },
+        }),
+      )
+    })
+  })
+
+  it('deletes customer', async () => {
+    const page = {
+      items: [
+        { id: 1, name: 'Cust1', watermark_policy: 'none', watermark_text: null },
+      ],
+      meta: { page: 1, limit: 10, total: 1 },
+    }
+    ;(apiClient.GET as jest.Mock).mockResolvedValue({ data: page })
+
+    render(<CustomersPage />)
+
+    await waitFor(() => expect(screen.getByDisplayValue('Cust1')).toBeInTheDocument())
+
+    fireEvent.click(screen.getByText('Delete'))
+
+    await waitFor(() => {
+      expect(apiClient.DELETE).toHaveBeenCalledWith(
+        '/customers/{id}',
+        expect.objectContaining({ params: { path: { id: 1 } } }),
+      )
+    })
+  })
+})

--- a/apps/web/src/pages/customers/index.tsx
+++ b/apps/web/src/pages/customers/index.tsx
@@ -1,0 +1,225 @@
+import { useEffect, useState } from 'react'
+import { apiClient } from '../../../lib/api'
+
+type Customer = {
+  id?: number
+  name?: string
+  watermark_policy?: string | null
+  watermark_text?: string | null
+}
+
+type PageMeta = {
+  page?: number
+  limit?: number
+  total?: number
+}
+
+export default function CustomersPage() {
+  const [customers, setCustomers] = useState<Customer[]>([])
+  const [meta, setMeta] = useState<PageMeta>({ page: 1, limit: 10, total: 0 })
+  const [newCustomer, setNewCustomer] = useState({
+    name: '',
+    watermark_policy: 'none',
+    watermark_text: '',
+  })
+
+  const fetchCustomers = async (page = meta.page, limit = meta.limit) => {
+    const { data } = await apiClient.GET('/customers', {
+      params: { query: { page, limit } },
+    })
+    if (data) {
+      setCustomers(data.items || [])
+      setMeta(data.meta || { page, limit, total: 0 })
+    }
+  }
+
+  useEffect(() => {
+    fetchCustomers()
+  }, [])
+
+  const handleCreate = async (e: React.FormEvent) => {
+    e.preventDefault()
+    await apiClient.POST('/customers', {
+      body: {
+        name: newCustomer.name,
+        watermark_policy: newCustomer.watermark_policy,
+        watermark_text: newCustomer.watermark_text || undefined,
+      },
+    })
+    setNewCustomer({ name: '', watermark_policy: 'none', watermark_text: '' })
+    fetchCustomers()
+  }
+
+  const handleFieldChange = (
+    index: number,
+    field: keyof Customer,
+    value: string,
+  ) => {
+    setCustomers((prev) => {
+      const copy = [...prev]
+      copy[index] = { ...copy[index], [field]: value }
+      return copy
+    })
+  }
+
+  const handleUpdate = async (c: Customer) => {
+    await apiClient.PATCH('/customers/{id}', {
+      params: { path: { id: c.id! } },
+      body: {
+        name: c.name,
+        watermark_policy: c.watermark_policy,
+        watermark_text: c.watermark_text,
+      },
+    })
+    fetchCustomers()
+  }
+
+  const handleDelete = async (id: number) => {
+    await apiClient.DELETE('/customers/{id}', { params: { path: { id } } })
+    setCustomers((prev) => prev.filter((c) => c.id !== id))
+  }
+
+  const totalPages = Math.ceil((meta.total || 0) / (meta.limit || 1)) || 1
+
+  const changePage = (newPage: number) => {
+    setMeta((m) => ({ ...m, page: newPage }))
+    fetchCustomers(newPage)
+  }
+
+  const handleFetch = (e: React.FormEvent) => {
+    e.preventDefault()
+    fetchCustomers()
+  }
+
+  return (
+    <div>
+      <form onSubmit={handleFetch} style={{ marginBottom: '1rem' }}>
+        <label>
+          Page:
+          <input
+            type="number"
+            value={meta.page}
+            onChange={(e) =>
+              setMeta((m) => ({ ...m, page: Number(e.target.value) }))
+            }
+          />
+        </label>
+        <label>
+          Limit:
+          <input
+            type="number"
+            value={meta.limit}
+            onChange={(e) =>
+              setMeta((m) => ({ ...m, limit: Number(e.target.value) }))
+            }
+          />
+        </label>
+        <button type="submit">Fetch</button>
+      </form>
+
+      <form onSubmit={handleCreate} style={{ marginBottom: '1rem' }}>
+        <input
+          placeholder="Name"
+          value={newCustomer.name}
+          onChange={(e) =>
+            setNewCustomer((c) => ({ ...c, name: e.target.value }))
+          }
+        />
+        <select
+          value={newCustomer.watermark_policy}
+          onChange={(e) =>
+            setNewCustomer((c) => ({
+              ...c,
+              watermark_policy: e.target.value,
+            }))
+          }
+        >
+          <option value="none">none</option>
+          <option value="default">default</option>
+          <option value="custom_text">custom_text</option>
+        </select>
+        <input
+          placeholder="Watermark Text"
+          value={newCustomer.watermark_text}
+          onChange={(e) =>
+            setNewCustomer((c) => ({
+              ...c,
+              watermark_text: e.target.value,
+            }))
+          }
+        />
+        <button type="submit">Create</button>
+      </form>
+
+      <table>
+        <thead>
+          <tr>
+            <th>ID</th>
+            <th>Name</th>
+            <th>Watermark Policy</th>
+            <th>Watermark Text</th>
+            <th>Actions</th>
+          </tr>
+        </thead>
+        <tbody>
+          {customers.map((c, idx) => (
+            <tr key={c.id}>
+              <td>{c.id}</td>
+              <td>
+                <input
+                  value={c.name || ''}
+                  onChange={(e) =>
+                    handleFieldChange(idx, 'name', e.target.value)
+                  }
+                />
+              </td>
+              <td>
+                <select
+                  value={c.watermark_policy || ''}
+                  onChange={(e) =>
+                    handleFieldChange(idx, 'watermark_policy', e.target.value)
+                  }
+                >
+                  <option value="none">none</option>
+                  <option value="default">default</option>
+                  <option value="custom_text">custom_text</option>
+                </select>
+              </td>
+              <td>
+                <input
+                  value={c.watermark_text || ''}
+                  onChange={(e) =>
+                    handleFieldChange(idx, 'watermark_text', e.target.value)
+                  }
+                />
+              </td>
+              <td>
+                <button onClick={() => handleUpdate(c)}>Save</button>
+                <button onClick={() => handleDelete(c.id!)}>Delete</button>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+
+      <div style={{ marginTop: '1rem' }}>
+        <button
+          disabled={meta.page === 1}
+          onClick={() => changePage((meta.page || 1) - 1)}
+        >
+          Prev
+        </button>
+        <span>
+          {meta.page} / {totalPages}
+        </span>
+        <button
+          disabled={meta.page === totalPages}
+          onClick={() => changePage((meta.page || 1) + 1)}
+        >
+          Next
+        </button>
+      </div>
+    </div>
+  )
+}
+

--- a/docs/web-tool/requirements.md
+++ b/docs/web-tool/requirements.md
@@ -34,6 +34,12 @@ Kernfunktionen:
 - Navigationsleiste nur für eingeloggte Nutzer mit Links zu `Photos`, `Users`, `Orders`, `Shares` und `Exports`.
 - Branding/Wasserzeichen-Policy je Kunde/Share (Agenturkunden i. d. R. ohne Wasserzeichen).
 
+## Kundenverwaltung
+
+- Kunden paginiert listen (`GET /customers`).
+- Neue Kunden anlegen (`POST /customers`).
+- Kunden bearbeiten (`PATCH /customers/{id}`) und löschen (`DELETE /customers/{id}`).
+
 ## Login-Flow
 
 - Nutzer meldet sich auf `/login` mit E-Mail und Passwort an.

--- a/packages/contracts/openapi.yaml
+++ b/packages/contracts/openapi.yaml
@@ -13,6 +13,7 @@ tags:
   - name: users
   - name: photos
   - name: locations
+  - name: customers
   - name: orders
   - name: shares
   - name: public-shares
@@ -545,6 +546,49 @@ paths:
                   updated: { type: integer }
                   errors: { type: array, items: { $ref: '#/components/schemas/Error' } }
 
+  /customers:
+    get:
+      tags: [customers]
+      summary: List customers
+      parameters:
+        - $ref: '#/components/parameters/page'
+        - $ref: '#/components/parameters/limit'
+      responses:
+        '200': { description: OK, content: { application/json: { schema: { $ref: '#/components/schemas/Page_Customer_' } } } }
+    post:
+      tags: [customers]
+      summary: Create customer
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: '#/components/schemas/CustomerCreate' }
+      responses:
+        '201': { description: Created, content: { application/json: { schema: { $ref: '#/components/schemas/Customer' } } } }
+
+  /customers/{id}:
+    patch:
+      tags: [customers]
+      summary: Update customer
+      parameters:
+        - $ref: '#/components/parameters/id'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: '#/components/schemas/CustomerUpdate' }
+      responses:
+        '200': { description: OK, content: { application/json: { schema: { $ref: '#/components/schemas/Customer' } } } }
+        '404': { $ref: '#/components/responses/NotFound' }
+    delete:
+      tags: [customers]
+      summary: Delete customer
+      parameters:
+        - $ref: '#/components/parameters/id'
+      responses:
+        '204': { description: No Content }
+        '404': { $ref: '#/components/responses/NotFound' }
+
   /orders:
     get:
       tags: [orders]
@@ -817,6 +861,13 @@ components:
           type: array
           items: { $ref: '#/components/schemas/Share' }
         meta: { $ref: '#/components/schemas/PageMeta' }
+    Page_Customer_:
+      type: object
+      properties:
+        items:
+          type: array
+          items: { $ref: '#/components/schemas/Customer' }
+        meta: { $ref: '#/components/schemas/PageMeta' }
     GeoPoint:
       type: object
       properties:
@@ -912,6 +963,26 @@ components:
         site_id: { type: string, nullable: true }
         device_id: { type: string, nullable: true }
         uploader_id: { type: string, nullable: true }
+    CustomerCreate:
+      type: object
+      required: [name]
+      properties:
+        name: { type: string }
+        watermark_policy: { $ref: '#/components/schemas/WatermarkPolicy', nullable: true }
+        watermark_text: { type: string, nullable: true }
+    CustomerUpdate:
+      type: object
+      properties:
+        name: { type: string, nullable: true }
+        watermark_policy: { $ref: '#/components/schemas/WatermarkPolicy', nullable: true }
+        watermark_text: { type: string, nullable: true }
+    Customer:
+      type: object
+      properties:
+        id: { type: integer }
+        name: { type: string }
+        watermark_policy: { $ref: '#/components/schemas/WatermarkPolicy', nullable: true }
+        watermark_text: { type: string, nullable: true }
     OrderCreate:
       type: object
       required: [customer_id, name, status]


### PR DESCRIPTION
## Summary
- add customer endpoints and schema to OpenAPI
- implement customer list/create/update/delete page
- document web-tool customer management

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_689e1a51b53c832b96f33d546143fb51