### PR TITLE
feat: add profile page for password & 2FA management

### DIFF
--- a/apps/web/lib/api-types.ts
+++ b/apps/web/lib/api-types.ts
@@ -221,6 +221,40 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/auth/2fa": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        /** Disable 2FA and require re-login */
+        delete: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description No Content */
+                204: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/auth/me": {
         parameters: {
             query?: never;
@@ -421,6 +455,48 @@ export interface paths {
                     content?: never;
                 };
                 404: components["responses"]["NotFound"];
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/auth/change-password": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Change user password */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": {
+                        current_password: string;
+                        new_password: string;
+                    };
+                };
+            };
+            responses: {
+                /** @description No Content */
+                204: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                401: components["responses"]["Unauthorized"];
             };
         };
         delete?: never;

--- a/apps/web/src/context/AuthContext.tsx
+++ b/apps/web/src/context/AuthContext.tsx
@@ -14,6 +14,7 @@ interface AuthContextValue {
   isAuthenticated: boolean;
   challenge: string | null;
   setChallenge: (token: string | null) => void;
+  disable2FA: () => Promise<void>;
 }
 
 const AuthContext = createContext<AuthContextValue | undefined>(undefined);
@@ -53,8 +54,25 @@ export const AuthProvider: React.FC<React.PropsWithChildren> = ({ children }) =>
     setChallenge(null);
   };
 
+  const disable2FA = async () => {
+    await apiClient.DELETE('/auth/2fa', {});
+    logout();
+  };
+
   return (
-    <AuthContext.Provider value={{ token, role, userId, login, logout, isAuthenticated: !!token, challenge, setChallenge }}>
+    <AuthContext.Provider
+      value={{
+        token,
+        role,
+        userId,
+        login,
+        logout,
+        isAuthenticated: !!token,
+        challenge,
+        setChallenge,
+        disable2FA,
+      }}
+    >
       {children}
     </AuthContext.Provider>
   );

--- a/apps/web/src/pages/__tests__/profile.test.tsx
+++ b/apps/web/src/pages/__tests__/profile.test.tsx
@@ -1,0 +1,92 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import ProfilePage from '../profile';
+import { AuthProvider } from '../../context/AuthContext';
+import { apiClient } from '../../../lib/api';
+import { useRouter } from 'next/router';
+
+jest.mock('next/router', () => ({
+  useRouter: jest.fn(),
+}));
+
+const mockedUseRouter = useRouter as jest.Mock;
+
+describe('ProfilePage', () => {
+  let store: Record<string, string>;
+
+  beforeEach(() => {
+    store = {};
+    Object.defineProperty(window, 'localStorage', {
+      value: {
+        getItem: jest.fn((key) => store[key]),
+        setItem: jest.fn((key, value) => {
+          store[key] = value;
+        }),
+        removeItem: jest.fn((key) => {
+          delete store[key];
+        }),
+      },
+      writable: true,
+    });
+    mockedUseRouter.mockReturnValue({
+      pathname: '/profile',
+      push: jest.fn(),
+      replace: jest.fn(),
+      prefetch: jest.fn(),
+      events: { on: jest.fn(), off: jest.fn() },
+      beforePopState: jest.fn(),
+    });
+    jest.spyOn(apiClient, 'GET').mockResolvedValue({
+      data: { id: 1, email: 'user@example.com', role: 'ADMIN' },
+    } as unknown as Awaited<ReturnType<typeof apiClient.GET>>);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('changes password', async () => {
+    const post = jest
+      .spyOn(apiClient, 'POST')
+      .mockResolvedValue({} as unknown as Awaited<ReturnType<typeof apiClient.POST>>);
+
+    render(
+      <AuthProvider>
+        <ProfilePage />
+      </AuthProvider>,
+    );
+
+    fireEvent.change(screen.getByPlaceholderText('Aktuelles Passwort'), {
+      target: { value: 'old' },
+    });
+    fireEvent.change(screen.getByPlaceholderText('Neues Passwort'), {
+      target: { value: 'new' },
+    });
+    fireEvent.click(screen.getByText('Passwort ändern'));
+
+    await waitFor(() => {
+      expect(post).toHaveBeenCalledWith('/auth/change-password', {
+        body: { current_password: 'old', new_password: 'new' },
+      });
+    });
+  });
+
+  it('disables 2FA and logs out', async () => {
+    store['token'] = 'token123';
+    const del = jest
+      .spyOn(apiClient, 'DELETE')
+      .mockResolvedValue({} as unknown as Awaited<ReturnType<typeof apiClient.DELETE>>);
+
+    render(
+      <AuthProvider>
+        <ProfilePage />
+      </AuthProvider>,
+    );
+
+    fireEvent.click(screen.getByText('2FA deaktivieren'));
+
+    await waitFor(() => {
+      expect(del).toHaveBeenCalledWith('/auth/2fa', {});
+      expect(window.localStorage.removeItem).toHaveBeenCalledWith('token');
+    });
+  });
+});

--- a/apps/web/src/pages/profile.tsx
+++ b/apps/web/src/pages/profile.tsx
@@ -1,0 +1,46 @@
+import { useState } from 'react';
+import { useRouter } from 'next/router';
+import { apiClient } from '../../lib/api';
+import { useAuth } from '../context/AuthContext';
+
+export default function ProfilePage() {
+  const [currentPassword, setCurrentPassword] = useState('');
+  const [newPassword, setNewPassword] = useState('');
+  const [message, setMessage] = useState<string | null>(null);
+  const { disable2FA } = useAuth();
+  const router = useRouter();
+
+  const handlePasswordChange = async (e: React.FormEvent) => {
+    e.preventDefault();
+    await apiClient.POST('/auth/change-password', {
+      body: { current_password: currentPassword, new_password: newPassword },
+    });
+    setMessage('Passwort geändert');
+    setCurrentPassword('');
+    setNewPassword('');
+  };
+
+  return (
+    <div>
+      <h1>Profil</h1>
+      <form onSubmit={handlePasswordChange}>
+        <input
+          type="password"
+          placeholder="Aktuelles Passwort"
+          value={currentPassword}
+          onChange={(e) => setCurrentPassword(e.target.value)}
+        />
+        <input
+          type="password"
+          placeholder="Neues Passwort"
+          value={newPassword}
+          onChange={(e) => setNewPassword(e.target.value)}
+        />
+        <button type="submit">Passwort ändern</button>
+      </form>
+      <button onClick={() => router.push('/2fa/setup')}>2FA aktivieren</button>
+      <button onClick={() => disable2FA()}>2FA deaktivieren</button>
+      {message && <p>{message}</p>}
+    </div>
+  );
+}

--- a/docs/web-tool/requirements.md
+++ b/docs/web-tool/requirements.md
@@ -34,6 +34,12 @@ Kernfunktionen:
 - Navigationsleiste nur für eingeloggte Nutzer mit Links zu `Photos`, `Users`, `Orders`, `Shares` und `Exports`.
 - Branding/Wasserzeichen-Policy je Kunde/Share (Agenturkunden i. d. R. ohne Wasserzeichen).
 
+## Profilverwaltung
+
+- Nutzer können ihr Passwort ändern (`POST /auth/change-password`).
+- Zwei-Faktor-Authentifizierung kann aktiviert (`POST /auth/2fa/setup`) oder deaktiviert (`DELETE /auth/2fa`) werden.
+- Nach Deaktivierung der 2FA wird der Nutzer ausgeloggt und muss sich erneut anmelden.
+
 ## Kundenverwaltung
 
 - Kunden paginiert listen (`GET /customers`).

--- a/packages/contracts/openapi.yaml
+++ b/packages/contracts/openapi.yaml
@@ -127,6 +127,13 @@ paths:
         '401':
           $ref: '#/components/responses/Unauthorized'
 
+  /auth/2fa:
+    delete:
+      tags: [auth]
+      summary: Disable 2FA and require re-login
+      responses:
+        '204': { description: No Content }
+
   /auth/me:
     get:
       tags: [auth]
@@ -222,6 +229,25 @@ paths:
         '204': { description: No Content }
         '404':
           $ref: '#/components/responses/NotFound'
+
+  /auth/change-password:
+    post:
+      tags: [auth]
+      summary: Change user password
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [current_password, new_password]
+              properties:
+                current_password: { type: string, minLength: 1 }
+                new_password: { type: string, minLength: 1 }
+      responses:
+        '204': { description: No Content }
+        '401':
+          $ref: '#/components/responses/Unauthorized'
 
   /users:
     get:


### PR DESCRIPTION
## Summary
- document POST /auth/change-password and DELETE /auth/2fa in OpenAPI
- add profile page with password change form and 2FA controls
- extend AuthContext with disable2FA that logs out after use
- cover profile flows with tests and document profile management

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_689e2684ed14832b966ceef596117321