### PR TITLE
feat(web): allow photo location correction

### DIFF
--- a/apps/web/src/pages/photos/[id].tsx
+++ b/apps/web/src/pages/photos/[id].tsx
@@ -1,6 +1,7 @@
 import { useRouter } from 'next/router'
 import { useEffect, useState } from 'react'
 import { apiClient } from '../../../lib/api'
+import PhotoMap from '../../components/PhotoMap'
 
 type Photo = {
   quality_flag?: string | null
@@ -9,6 +10,7 @@ type Photo = {
   site_id?: string | null
   device_id?: string | null
   uploader_id?: string | null
+  ad_hoc_spot?: { lat: number; lon: number } | null
 }
 
 export default function PhotoDetailPage() {
@@ -51,7 +53,8 @@ export default function PhotoDetailPage() {
   }
 
   return (
-    <form onSubmit={handleSubmit}>
+    <>
+      <form onSubmit={handleSubmit}>
       <label>
         Quality Flag:
         <input
@@ -97,7 +100,14 @@ export default function PhotoDetailPage() {
         />
       </label>
       <button type="submit">Save</button>
-    </form>
+      </form>
+      {id && photo.ad_hoc_spot && (
+        <PhotoMap
+          photoId={Number(id)}
+          adHocSpot={{ lat: photo.ad_hoc_spot.lat, lon: photo.ad_hoc_spot.lon }}
+        />
+      )}
+    </>
   )
 }
 

--- a/docs/web-tool/requirements.md
+++ b/docs/web-tool/requirements.md
@@ -21,7 +21,8 @@ Kernfunktionen:
 - Auftragsverwaltung: Aufträge listen, nach Kunde und Status filtern, neue Aufträge anlegen sowie Details ansehen und den Status bearbeiten (`GET /orders/{id}`, `PATCH /orders/{id}`).
 - Standortpflege: Standorte suchen (`q`, `near`, `radius_m`), paginiert listen und Name, Adresse oder Aktivstatus bearbeiten (`PATCH /locations/{id}`).
 - Foto-Detailseite zur Bearbeitung von Metadaten (`quality_flag`, `note`, ...)
-  über `PATCH /photos/{id}`.
+  über `PATCH /photos/{id}` und Korrektur des Standorts per Karte
+  (Marker-Drag mit `PATCH /photos/{id}` aktualisiert die Koordinaten).
 - Foto-Upload: Browser fordert über `POST /photos/upload-intent` eine signierte URL an und lädt die Datei direkt hoch.
 - Authentifizierung via Token: Browser speichert das Token und sendet es bei jeder API-Anfrage als `Authorization: Bearer <token>`.
 - `AuthContext` verwaltet Loginstatus und Token im Frontend.


### PR DESCRIPTION
## Summary
- enable `PhotoMap` to display a single draggable marker and save new coordinates
- show map on photo detail page for manual location correction
- document coordinate correction in web-tool requirements

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_689e38451858832ba8df6afeef5bee03