### PR TITLE
Redirect to login after password reset

### DIFF
--- a/apps/web/src/pages/__tests__/reset.test.tsx
+++ b/apps/web/src/pages/__tests__/reset.test.tsx
@@ -2,6 +2,7 @@ import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import ResetPage from '../reset/[token]';
 import { apiClient } from '../../../lib/api';
 import { useRouter } from 'next/router';
+import { ToastProvider } from '../../components/Toast';
 
 jest.mock('next/router', () => ({
   useRouter: jest.fn(),
@@ -13,18 +14,26 @@ jest.mock('../../../lib/api', () => ({
 
 const mockedUseRouter = useRouter as jest.Mock;
 
+let replace: jest.Mock;
+
 describe('ResetPage', () => {
   beforeEach(() => {
     jest.resetAllMocks();
+    replace = jest.fn();
     mockedUseRouter.mockReturnValue({
       query: { token: 'tok1' },
+      replace,
     });
   });
 
   it('posts token and password', async () => {
     (apiClient.POST as jest.Mock).mockResolvedValue({ error: undefined });
 
-    render(<ResetPage />);
+    render(
+      <ToastProvider>
+        <ResetPage />
+      </ToastProvider>,
+    );
 
     fireEvent.change(screen.getByPlaceholderText('Password'), {
       target: { value: 'pw' },
@@ -35,16 +44,21 @@ describe('ResetPage', () => {
       expect(apiClient.POST).toHaveBeenCalledWith('/auth/reset', {
         body: { token: 'tok1', password: 'pw' },
       });
-      expect(
-        screen.getByText('Password reset. You can now log in.'),
-      ).toBeInTheDocument();
+      expect(replace).toHaveBeenCalledWith('/login');
+      expect(screen.getByRole('alert')).toHaveTextContent(
+        'Password reset. You can now log in.',
+      );
     });
   });
 
   it('shows error on failure', async () => {
     (apiClient.POST as jest.Mock).mockResolvedValue({ error: {} });
 
-    render(<ResetPage />);
+    render(
+      <ToastProvider>
+        <ResetPage />
+      </ToastProvider>,
+    );
 
     fireEvent.change(screen.getByPlaceholderText('Password'), {
       target: { value: 'pw' },

--- a/apps/web/src/pages/reset/[token].tsx
+++ b/apps/web/src/pages/reset/[token].tsx
@@ -1,13 +1,14 @@
 import { useRouter } from 'next/router';
 import { useState } from 'react';
 import { apiClient } from '../../../lib/api';
+import { useToast } from '../../components/Toast';
 
 export default function ResetPage() {
   const router = useRouter();
   const { token } = router.query;
   const [password, setPassword] = useState('');
   const [error, setError] = useState<string | null>(null);
-  const [success, setSuccess] = useState(false);
+  const { showToast } = useToast();
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -19,7 +20,8 @@ export default function ResetPage() {
     if (err) {
       setError('Reset failed');
     } else {
-      setSuccess(true);
+      showToast('success', 'Password reset. You can now log in.');
+      router.replace('/login');
     }
   };
 
@@ -37,7 +39,6 @@ export default function ResetPage() {
           {error}
         </div>
       )}
-      {success && <div>Password reset. You can now log in.</div>}
     </form>
   );
 }

--- a/docs/web-tool/requirements.md
+++ b/docs/web-tool/requirements.md
@@ -85,7 +85,7 @@ Kernfunktionen:
 - Nutzer fordert über `/forgot-password` einen Reset an (`POST /auth/reset-request`).
 - Er erhält einen Link `/reset/{token}` per E-Mail.
 - Auf der Reset-Seite setzt der Nutzer ein neues Passwort; das Frontend sendet `POST /auth/reset` mit Token und Passwort.
-- Nach erfolgreichem Reset kann sich der Nutzer mit dem neuen Passwort anmelden.
+- Nach erfolgreichem Reset leitet das Frontend auf `/login` weiter und zeigt einen Erfolgs-Toast an; anschließend kann sich der Nutzer mit dem neuen Passwort anmelden.
 
 ## Plakatierer-Flow
 


### PR DESCRIPTION
## Summary
- redirect to `/login` and show success toast after password reset
- test reset flow for toast and redirect
- document redirect behavior in password reset requirements

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_689e3a5e51c8832bb38d0d95cc3ae581