### PR TITLE
Restrict admin navigation links to admins

### DIFF
--- a/apps/web/src/components/Layout.tsx
+++ b/apps/web/src/components/Layout.tsx
@@ -4,7 +4,7 @@ import { useRouter } from 'next/router';
 import { useAuth } from '../context/AuthContext';
 
 export default function Layout({ children }: { children: ReactNode }) {
-  const { logout, isAuthenticated } = useAuth();
+  const { logout, isAuthenticated, role } = useAuth();
   const router = useRouter();
 
   const handleLogout = () => {
@@ -20,9 +20,10 @@ export default function Layout({ children }: { children: ReactNode }) {
         <nav className="navbar">
           <div className="nav-links">
             <Link href="/photos">Photos</Link>
-            <Link href="/users">Users</Link>
+            {role === 'ADMIN' && <Link href="/users">Users</Link>}
             <Link href="/orders">Orders</Link>
-            <Link href="/shares">Shares</Link>
+            {role === 'ADMIN' && <Link href="/shares">Shares</Link>}
+            {role === 'ADMIN' && <Link href="/locations">Locations</Link>}
             <Link href="/exports">Exports</Link>
           </div>
           <button className="logout-button" onClick={handleLogout}>

--- a/apps/web/src/pages/__tests__/login.test.tsx
+++ b/apps/web/src/pages/__tests__/login.test.tsx
@@ -287,49 +287,81 @@ describe('LoginPage', () => {
     expect(push).toHaveBeenCalledWith('/login');
   });
 
-    it('renders exports link in navigation', () => {
-      store['token'] = 'token123';
-      const push = jest.fn();
-      mockedUseRouter.mockReturnValue({
-        pathname: '/photos',
-        replace: push,
-        push,
-        prefetch: jest.fn(),
-        events: { on: jest.fn(), off: jest.fn() },
-        beforePopState: jest.fn(),
-      });
-
-      render(
-        <AuthProvider>
-          <Layout>
-            <div>content</div>
-          </Layout>
-        </AuthProvider>,
-      );
-
-      expect(screen.getByText('Exports')).toBeInTheDocument();
+  it('renders exports link in navigation', () => {
+    store['token'] = 'token123';
+    const push = jest.fn();
+    mockedUseRouter.mockReturnValue({
+      pathname: '/photos',
+      replace: push,
+      push,
+      prefetch: jest.fn(),
+      events: { on: jest.fn(), off: jest.fn() },
+      beforePopState: jest.fn(),
     });
 
-    it('does not render navigation links when unauthenticated', () => {
-      const push = jest.fn();
-      mockedUseRouter.mockReturnValue({
-        pathname: '/photos',
-        replace: push,
-        push,
-        prefetch: jest.fn(),
-        events: { on: jest.fn(), off: jest.fn() },
-        beforePopState: jest.fn(),
-      });
+    render(
+      <AuthProvider>
+        <Layout>
+          <div>content</div>
+        </Layout>
+      </AuthProvider>,
+    );
 
-      render(
-        <AuthProvider>
-          <Layout>
-            <div>content</div>
-          </Layout>
-        </AuthProvider>,
-      );
+    expect(screen.getByText('Exports')).toBeInTheDocument();
+  });
 
-      expect(screen.queryByText('Photos')).not.toBeInTheDocument();
-      expect(screen.queryByText('Exports')).not.toBeInTheDocument();
+  it('hides admin links for non-admin users', async () => {
+    store['token'] = 'token123';
+    (apiClient.GET as jest.Mock).mockResolvedValueOnce({
+      data: { id: 1, email: 'user@example.com', role: 'USER' },
+    } as unknown as Awaited<ReturnType<typeof apiClient.GET>>);
+    const push = jest.fn();
+    mockedUseRouter.mockReturnValue({
+      pathname: '/photos',
+      replace: push,
+      push,
+      prefetch: jest.fn(),
+      events: { on: jest.fn(), off: jest.fn() },
+      beforePopState: jest.fn(),
     });
+
+    render(
+      <AuthProvider>
+        <Layout>
+          <div>content</div>
+        </Layout>
+      </AuthProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Photos')).toBeInTheDocument();
+    });
+
+    expect(screen.queryByText('Users')).not.toBeInTheDocument();
+    expect(screen.queryByText('Shares')).not.toBeInTheDocument();
+    expect(screen.queryByText('Locations')).not.toBeInTheDocument();
+  });
+
+  it('does not render navigation links when unauthenticated', () => {
+    const push = jest.fn();
+    mockedUseRouter.mockReturnValue({
+      pathname: '/photos',
+      replace: push,
+      push,
+      prefetch: jest.fn(),
+      events: { on: jest.fn(), off: jest.fn() },
+      beforePopState: jest.fn(),
+    });
+
+    render(
+      <AuthProvider>
+        <Layout>
+          <div>content</div>
+        </Layout>
+      </AuthProvider>,
+    );
+
+    expect(screen.queryByText('Photos')).not.toBeInTheDocument();
+    expect(screen.queryByText('Exports')).not.toBeInTheDocument();
+  });
   });

--- a/docs/web-tool/requirements.md
+++ b/docs/web-tool/requirements.md
@@ -32,7 +32,7 @@ Kernfunktionen:
 - Logout löscht das Token und navigiert zu `/login`.
 - Bei abgelaufener Sitzung (HTTP 401) löscht das Frontend das Token und leitet automatisch auf `/login` weiter.
 - Registrierung neuer Nutzer über Formular (`POST /auth/register`), leitet nach erfolgreicher Registrierung zu `/login`.
-- Navigationsleiste nur für eingeloggte Nutzer mit Links zu `Photos`, `Users`, `Orders`, `Shares` und `Exports`.
+- Navigationsleiste nur für eingeloggte Nutzer mit Links zu `Photos`, `Orders` und `Exports`; Admins sehen zusätzlich `Users`, `Shares` und `Locations`.
 - Branding/Wasserzeichen-Policy je Kunde/Share (Agenturkunden i. d. R. ohne Wasserzeichen).
 
 ## Profilverwaltung


### PR DESCRIPTION
## Summary
- Show Users, Shares, and Locations navigation items only when authenticated role is ADMIN
- Test that non-admin users do not see admin navigation links
- Document that only admins see Users, Shares, and Locations links in the navigation

## Testing
- `npm install`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_689e41ec67f4832b8ae1e61124bee89f