### PR TITLE
feat(web): add toast notifications to auth and detail pages

### DIFF
--- a/apps/web/src/pages/__tests__/forgot-password.test.tsx
+++ b/apps/web/src/pages/__tests__/forgot-password.test.tsx
@@ -1,10 +1,18 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import ForgotPasswordPage from '../forgot-password';
 import { apiClient } from '../../../lib/api';
+import { ToastProvider } from '../../components/Toast';
+import { useRouter } from 'next/router';
 
 jest.mock('../../../lib/api', () => ({
   apiClient: { POST: jest.fn() },
 }));
+
+jest.mock('next/router', () => ({
+  useRouter: jest.fn(),
+}));
+
+const mockedUseRouter = useRouter as jest.Mock;
 
 describe('ForgotPasswordPage', () => {
   beforeEach(() => {
@@ -12,9 +20,15 @@ describe('ForgotPasswordPage', () => {
   });
 
   it('shows confirmation on success', async () => {
+    const push = jest.fn();
+    mockedUseRouter.mockReturnValue({ push });
     (apiClient.POST as jest.Mock).mockResolvedValue({ error: undefined });
 
-    render(<ForgotPasswordPage />);
+    render(
+      <ToastProvider>
+        <ForgotPasswordPage />
+      </ToastProvider>,
+    );
 
     fireEvent.change(screen.getByPlaceholderText('Email'), {
       target: { value: 'user@example.com' },
@@ -25,22 +39,31 @@ describe('ForgotPasswordPage', () => {
       expect(apiClient.POST).toHaveBeenCalledWith('/auth/reset-request', {
         body: { email: 'user@example.com' },
       });
-      expect(screen.getByText('Check your email')).toBeInTheDocument();
+      expect(push).toHaveBeenCalledWith('/login');
     });
+
+    await waitFor(() =>
+      expect(screen.getByRole('alert')).toHaveTextContent('Check your email'),
+    );
   });
 
   it('shows error on failure', async () => {
+    mockedUseRouter.mockReturnValue({ push: jest.fn() });
     (apiClient.POST as jest.Mock).mockResolvedValue({ error: {} });
 
-    render(<ForgotPasswordPage />);
+    render(
+      <ToastProvider>
+        <ForgotPasswordPage />
+      </ToastProvider>,
+    );
 
     fireEvent.change(screen.getByPlaceholderText('Email'), {
       target: { value: 'user@example.com' },
     });
     fireEvent.click(screen.getByText('Send reset link'));
 
-    await waitFor(() => {
-      expect(screen.getByRole('alert')).toHaveTextContent('Reset failed');
-    });
+    await waitFor(() =>
+      expect(screen.getByRole('alert')).toHaveTextContent('Reset failed'),
+    );
   });
 });

--- a/apps/web/src/pages/__tests__/orders.test.tsx
+++ b/apps/web/src/pages/__tests__/orders.test.tsx
@@ -143,7 +143,11 @@ describe('OrderDetailPage', () => {
       data: { customer_id: 'c1', name: 'Order 1', status: 'reserved' },
     })
 
-    render(<OrderDetailPage />)
+    render(
+      <ToastProvider>
+        <OrderDetailPage />
+      </ToastProvider>,
+    )
     await waitFor(() => expect(apiClient.GET).toHaveBeenCalled())
 
     fireEvent.change(screen.getByLabelText('Status:'), {
@@ -159,6 +163,10 @@ describe('OrderDetailPage', () => {
           body: expect.objectContaining({ status: 'booked' }),
         }),
       ),
+    )
+
+    await waitFor(() =>
+      expect(screen.getByRole('alert')).toHaveTextContent('Order updated'),
     )
   })
 })

--- a/apps/web/src/pages/__tests__/photos.test.tsx
+++ b/apps/web/src/pages/__tests__/photos.test.tsx
@@ -589,7 +589,11 @@ describe('PhotoDetailPage', () => {
     ;(apiClient.GET as jest.Mock).mockResolvedValue({
       data: { quality_flag: 'ok', note: 'old' },
     })
-    render(<PhotoDetailPage />)
+    render(
+      <ToastProvider>
+        <PhotoDetailPage />
+      </ToastProvider>,
+    )
     await waitFor(() => expect(apiClient.GET).toHaveBeenCalled())
     fireEvent.change(screen.getByLabelText('Quality Flag:'), {
       target: { value: 'bad' },
@@ -610,6 +614,10 @@ describe('PhotoDetailPage', () => {
         }),
       ),
     )
+
+    await waitFor(() =>
+      expect(screen.getByRole('alert')).toHaveTextContent('Photo updated'),
+    )
   })
 
   it('sends updated coordinates on marker drag', async () => {
@@ -617,7 +625,11 @@ describe('PhotoDetailPage', () => {
     ;(apiClient.GET as jest.Mock).mockResolvedValue({
       data: { ad_hoc_spot: { lat: 1, lon: 1 } },
     })
-    render(<PhotoDetailPage />)
+    render(
+      <ToastProvider>
+        <PhotoDetailPage />
+      </ToastProvider>,
+    )
     await waitFor(() => expect(apiClient.GET).toHaveBeenCalled())
     await waitFor(() =>
       expect(screen.getAllByTestId('marker').length).toBeGreaterThan(0),

--- a/apps/web/src/pages/__tests__/profile.test.tsx
+++ b/apps/web/src/pages/__tests__/profile.test.tsx
@@ -3,6 +3,7 @@ import ProfilePage from '../profile';
 import { AuthProvider } from '../../context/AuthContext';
 import { apiClient } from '../../../lib/api';
 import { useRouter } from 'next/router';
+import { ToastProvider } from '../../components/Toast';
 
 jest.mock('next/router', () => ({
   useRouter: jest.fn(),
@@ -51,7 +52,9 @@ describe('ProfilePage', () => {
 
     render(
       <AuthProvider>
-        <ProfilePage />
+        <ToastProvider>
+          <ProfilePage />
+        </ToastProvider>
       </AuthProvider>,
     );
 
@@ -68,6 +71,10 @@ describe('ProfilePage', () => {
         body: { current_password: 'old', new_password: 'new' },
       });
     });
+
+    await waitFor(() =>
+      expect(screen.getByRole('alert')).toHaveTextContent('Passwort geändert'),
+    );
   });
 
   it('disables 2FA and logs out', async () => {
@@ -78,7 +85,9 @@ describe('ProfilePage', () => {
 
     render(
       <AuthProvider>
-        <ProfilePage />
+        <ToastProvider>
+          <ProfilePage />
+        </ToastProvider>
       </AuthProvider>,
     );
 
@@ -88,5 +97,9 @@ describe('ProfilePage', () => {
       expect(del).toHaveBeenCalledWith('/auth/2fa', {});
       expect(window.localStorage.removeItem).toHaveBeenCalledWith('token');
     });
+
+    await waitFor(() =>
+      expect(screen.getByRole('alert')).toHaveTextContent('2FA deaktiviert'),
+    );
   });
 });

--- a/apps/web/src/pages/__tests__/register.test.tsx
+++ b/apps/web/src/pages/__tests__/register.test.tsx
@@ -2,6 +2,7 @@ import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import RegisterPage from '../register'
 import { apiClient } from '../../../lib/api'
 import { useRouter } from 'next/router'
+import { ToastProvider } from '../../components/Toast'
 
 jest.mock('next/router', () => ({
   useRouter: jest.fn(),
@@ -24,7 +25,11 @@ describe('RegisterPage', () => {
         ReturnType<typeof apiClient.POST>
       >)
 
-    render(<RegisterPage />)
+    render(
+      <ToastProvider>
+        <RegisterPage />
+      </ToastProvider>,
+    )
 
     fireEvent.change(screen.getByPlaceholderText('Email'), {
       target: { value: 'user@example.com' },
@@ -37,6 +42,12 @@ describe('RegisterPage', () => {
     await waitFor(() => {
       expect(push).toHaveBeenCalledWith('/login')
     })
+
+    await waitFor(() =>
+      expect(screen.getByRole('alert')).toHaveTextContent(
+        'Registration successful',
+      ),
+    )
   })
 
   it('shows error on failed registration', async () => {
@@ -47,7 +58,11 @@ describe('RegisterPage', () => {
         ReturnType<typeof apiClient.POST>
       >)
 
-    render(<RegisterPage />)
+    render(
+      <ToastProvider>
+        <RegisterPage />
+      </ToastProvider>,
+    )
 
     fireEvent.change(screen.getByPlaceholderText('Email'), {
       target: { value: 'user@example.com' },
@@ -57,8 +72,8 @@ describe('RegisterPage', () => {
     })
     fireEvent.click(screen.getByText('Register'))
 
-    await waitFor(() => {
-      expect(screen.getByRole('alert')).toHaveTextContent('Registration failed')
-    })
+    await waitFor(() =>
+      expect(screen.getByRole('alert')).toHaveTextContent('Registration failed'),
+    )
   })
 })

--- a/apps/web/src/pages/accept/[token].tsx
+++ b/apps/web/src/pages/accept/[token].tsx
@@ -1,25 +1,29 @@
 import { useRouter } from 'next/router';
 import { useState } from 'react';
 import { apiClient } from '../../../lib/api';
+import { useToast } from '../../components/Toast';
 
 export default function AcceptPage() {
   const router = useRouter();
   const { token } = router.query;
   const [password, setPassword] = useState('');
-  const [error, setError] = useState<string | null>(null);
-  const [success, setSuccess] = useState(false);
+  const { showToast } = useToast();
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    setError(null);
     if (!token || Array.isArray(token)) return;
-    const { error: err } = await apiClient.POST('/auth/accept', {
-      body: { token, password },
-    });
-    if (err) {
-      setError('Accept failed');
-    } else {
-      setSuccess(true);
+    try {
+      const { error } = await apiClient.POST('/auth/accept', {
+        body: { token, password },
+      });
+      if (error) {
+        showToast('error', 'Accept failed');
+      } else {
+        showToast('success', 'Password set. You can now log in.');
+        router.push('/login');
+      }
+    } catch {
+      showToast('error', 'Accept failed');
     }
   };
 
@@ -32,12 +36,6 @@ export default function AcceptPage() {
         onChange={(e) => setPassword(e.target.value)}
       />
       <button type="submit">Set Password</button>
-      {error && (
-        <div role="alert" style={{ color: 'red' }}>
-          {error}
-        </div>
-      )}
-      {success && <div>Password set. You can now log in.</div>}
     </form>
   );
 }

--- a/apps/web/src/pages/forgot-password.tsx
+++ b/apps/web/src/pages/forgot-password.tsx
@@ -1,22 +1,27 @@
 import { useState } from 'react';
+import { useRouter } from 'next/router';
 import { apiClient } from '../../lib/api';
+import { useToast } from '../components/Toast';
 
 export default function ForgotPasswordPage() {
   const [email, setEmail] = useState('');
-  const [message, setMessage] = useState<string | null>(null);
-  const [error, setError] = useState<string | null>(null);
+  const router = useRouter();
+  const { showToast } = useToast();
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    setError(null);
-    setMessage(null);
-    const { error: err } = await apiClient.POST('/auth/reset-request', {
-      body: { email },
-    });
-    if (err) {
-      setError('Reset failed');
-    } else {
-      setMessage('Check your email');
+    try {
+      const { error } = await apiClient.POST('/auth/reset-request', {
+        body: { email },
+      });
+      if (error) {
+        showToast('error', 'Reset failed');
+      } else {
+        showToast('success', 'Check your email');
+        router.push('/login');
+      }
+    } catch {
+      showToast('error', 'Reset failed');
     }
   };
 
@@ -28,12 +33,6 @@ export default function ForgotPasswordPage() {
         onChange={(e) => setEmail(e.target.value)}
       />
       <button type="submit">Send reset link</button>
-      {error && (
-        <div role="alert" style={{ color: 'red' }}>
-          {error}
-        </div>
-      )}
-      {message && <div role="status">{message}</div>}
     </form>
   );
 }

--- a/apps/web/src/pages/orders/[id].tsx
+++ b/apps/web/src/pages/orders/[id].tsx
@@ -1,6 +1,7 @@
 import { useRouter } from 'next/router'
 import { useEffect, useState } from 'react'
 import { apiClient } from '../../../lib/api'
+import { useToast } from '../../components/Toast'
 
 type Order = {
   customer_id?: string
@@ -12,6 +13,7 @@ export default function OrderDetailPage() {
   const router = useRouter()
   const { id } = router.query
   const [order, setOrder] = useState<Order>({})
+  const { showToast } = useToast()
 
   useEffect(() => {
     if (!id) return
@@ -34,14 +36,19 @@ export default function OrderDetailPage() {
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
     if (!id) return
-    await apiClient.PATCH('/orders/{id}', {
-      params: { path: { id: Number(id) } },
-      body: {
-        customer_id: order.customer_id || '',
-        name: order.name || '',
-        status: order.status || '',
-      },
-    })
+    try {
+      await apiClient.PATCH('/orders/{id}', {
+        params: { path: { id: Number(id) } },
+        body: {
+          customer_id: order.customer_id || '',
+          name: order.name || '',
+          status: order.status || '',
+        },
+      })
+      showToast('success', 'Order updated')
+    } catch {
+      showToast('error', 'Update failed')
+    }
   }
 
   return (

--- a/apps/web/src/pages/photos/[id].tsx
+++ b/apps/web/src/pages/photos/[id].tsx
@@ -2,6 +2,7 @@ import { useRouter } from 'next/router'
 import { useEffect, useState } from 'react'
 import { apiClient } from '../../../lib/api'
 import PhotoMap from '../../components/PhotoMap'
+import { useToast } from '../../components/Toast'
 
 type Photo = {
   quality_flag?: string | null
@@ -17,6 +18,7 @@ export default function PhotoDetailPage() {
   const router = useRouter()
   const { id } = router.query
   const [photo, setPhoto] = useState<Photo>({})
+  const { showToast } = useToast()
 
   useEffect(() => {
     if (!id) return
@@ -39,17 +41,22 @@ export default function PhotoDetailPage() {
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
     if (!id) return
-    await apiClient.PATCH('/photos/{id}', {
-      params: { path: { id: Number(id) } },
-      body: {
-        quality_flag: photo.quality_flag || null,
-        note: photo.note || null,
-        mode: photo.mode || null,
-        site_id: photo.site_id || null,
-        device_id: photo.device_id || null,
-        uploader_id: photo.uploader_id || null,
-      },
-    })
+    try {
+      await apiClient.PATCH('/photos/{id}', {
+        params: { path: { id: Number(id) } },
+        body: {
+          quality_flag: photo.quality_flag || null,
+          note: photo.note || null,
+          mode: photo.mode || null,
+          site_id: photo.site_id || null,
+          device_id: photo.device_id || null,
+          uploader_id: photo.uploader_id || null,
+        },
+      })
+      showToast('success', 'Photo updated')
+    } catch {
+      showToast('error', 'Update failed')
+    }
   }
 
   return (

--- a/apps/web/src/pages/profile.tsx
+++ b/apps/web/src/pages/profile.tsx
@@ -2,22 +2,36 @@ import { useState } from 'react';
 import { useRouter } from 'next/router';
 import { apiClient } from '../../lib/api';
 import { useAuth } from '../context/AuthContext';
+import { useToast } from '../components/Toast';
 
 export default function ProfilePage() {
   const [currentPassword, setCurrentPassword] = useState('');
   const [newPassword, setNewPassword] = useState('');
-  const [message, setMessage] = useState<string | null>(null);
   const { disable2FA } = useAuth();
   const router = useRouter();
+  const { showToast } = useToast();
 
   const handlePasswordChange = async (e: React.FormEvent) => {
     e.preventDefault();
-    await apiClient.POST('/auth/change-password', {
-      body: { current_password: currentPassword, new_password: newPassword },
-    });
-    setMessage('Passwort geändert');
-    setCurrentPassword('');
-    setNewPassword('');
+    try {
+      await apiClient.POST('/auth/change-password', {
+        body: { current_password: currentPassword, new_password: newPassword },
+      });
+      showToast('success', 'Passwort geändert');
+      setCurrentPassword('');
+      setNewPassword('');
+    } catch {
+      showToast('error', 'Passwortänderung fehlgeschlagen');
+    }
+  };
+
+  const handleDisable2FA = async () => {
+    try {
+      await disable2FA();
+      showToast('success', '2FA deaktiviert');
+    } catch {
+      showToast('error', '2FA konnte nicht deaktiviert werden');
+    }
   };
 
   return (
@@ -39,8 +53,7 @@ export default function ProfilePage() {
         <button type="submit">Passwort ändern</button>
       </form>
       <button onClick={() => router.push('/2fa/setup')}>2FA aktivieren</button>
-      <button onClick={() => disable2FA()}>2FA deaktivieren</button>
-      {message && <p>{message}</p>}
+      <button onClick={handleDisable2FA}>2FA deaktivieren</button>
     </div>
   );
 }

--- a/apps/web/src/pages/register.tsx
+++ b/apps/web/src/pages/register.tsx
@@ -1,23 +1,28 @@
 import { useState } from 'react'
 import { useRouter } from 'next/router'
 import { apiClient } from '../../lib/api'
+import { useToast } from '../components/Toast'
 
 export default function RegisterPage() {
   const [email, setEmail] = useState('')
   const [password, setPassword] = useState('')
-  const [error, setError] = useState<string | null>(null)
   const router = useRouter()
+  const { showToast } = useToast()
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
-    setError(null)
-    const { data } = await apiClient.POST('/auth/register', {
-      body: { email, password },
-    })
-    if (data) {
-      router.push('/login')
-    } else {
-      setError('Registration failed')
+    try {
+      const { data } = await apiClient.POST('/auth/register', {
+        body: { email, password },
+      })
+      if (data) {
+        showToast('success', 'Registration successful')
+        router.push('/login')
+      } else {
+        showToast('error', 'Registration failed')
+      }
+    } catch {
+      showToast('error', 'Registration failed')
     }
   }
 
@@ -35,11 +40,6 @@ export default function RegisterPage() {
         onChange={(e) => setPassword(e.target.value)}
       />
       <button type="submit">Register</button>
-      {error && (
-        <div role="alert" style={{ color: 'red' }}>
-          {error}
-        </div>
-      )}
     </form>
   )
 }

--- a/docs/web-tool/requirements.md
+++ b/docs/web-tool/requirements.md
@@ -105,4 +105,4 @@ UX/Leistung:
 
 - Zentrale Toast-Komponente f\u00fcr Erfolg- und Fehlermeldungen.
 - `AuthGuard` informiert \u00fcber fehlende Berechtigungen oder nicht eingeloggte Nutzer.
-- Seiten wie `Photos`, `Orders`, `Shares`, `Users`, `Customers` und `Locations` zeigen Ergebnis von API-Aktionen über Toasts an (z. B. Einladungen oder Rollenänderungen, Kundenanlage/-aktualisierung, Standort-Updates).
+- Seiten wie `Register`, `Forgot Password`, `Accept`, `Profile`, `Photos`, `Orders` (inkl. Detailseiten), `Shares`, `Users`, `Customers` und `Locations` zeigen Ergebnis von API-Aktionen über Toasts an (z. B. Einladungen oder Rollenänderungen, Kundenanlage/-aktualisierung, Standort-Updates).


### PR DESCRIPTION
## Summary
- show toast messages on register, forgot-password, and accept flows
- display success/error toasts on profile, photo, and order detail updates
- document toast usage across additional pages

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_689e4f2b4800832ba19ef7367e23d9f6