### PR TITLE
fix: load PhotoMap only on client

### DIFF
--- a/apps/web/src/pages/photos/[id].tsx
+++ b/apps/web/src/pages/photos/[id].tsx
@@ -1,8 +1,12 @@
 import { useRouter } from 'next/router'
 import { useEffect, useState } from 'react'
+import dynamic from 'next/dynamic'
 import { apiClient } from '../../../lib/api'
-import PhotoMap from '../../components/PhotoMap'
 import { useToast } from '../../components/Toast'
+
+const PhotoMap = dynamic(() => import('../../components/PhotoMap'), {
+  ssr: false,
+})
 
 type Photo = {
   quality_flag?: string | null

--- a/apps/web/src/pages/photos/index.tsx
+++ b/apps/web/src/pages/photos/index.tsx
@@ -1,8 +1,8 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
+import dynamic from 'next/dynamic'
 import { apiClient } from '../../../lib/api'
 import { useAuth } from '../../context/AuthContext'
 import { undoStack } from '../../lib/undoStack'
-import PhotoMap from '../../components/PhotoMap'
 import PhotoUpload from '../../components/PhotoUpload'
 import { useToast } from '../../components/Toast'
 import {
@@ -10,6 +10,10 @@ import {
   loadExportJobs,
   saveExportJobs,
 } from '../../../lib/exportJobs'
+
+const PhotoMap = dynamic(() => import('../../components/PhotoMap'), {
+  ssr: false,
+})
 
 type Photo = {
   id?: number

--- a/apps/web/src/pages/public/[token]/index.tsx
+++ b/apps/web/src/pages/public/[token]/index.tsx
@@ -1,12 +1,16 @@
 import { useRouter } from 'next/router'
 import { useEffect, useState } from 'react'
+import dynamic from 'next/dynamic'
 import { apiClient } from '../../../../lib/api'
-import PhotoMap from '../../../components/PhotoMap'
 import {
   ExportJob,
   loadExportJobs,
   saveExportJobs,
 } from '../../../../lib/exportJobs'
+
+const PhotoMap = dynamic(() => import('../../../components/PhotoMap'), {
+  ssr: false,
+})
 
 type Photo = {
   id: number


### PR DESCRIPTION
## Summary
- load `PhotoMap` with `next/dynamic` and `ssr: false` on pages using Leaflet

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_689e518fcab0832b8f8070e7a6db0e35