### PR TITLE
Redirect 2FA verification to photo gallery

### DIFF
--- a/apps/web/src/pages/2fa/verify.tsx
+++ b/apps/web/src/pages/2fa/verify.tsx
@@ -23,7 +23,7 @@ export default function TwoFAVerifyPage() {
     });
     if (data?.access_token) {
       login(data.access_token);
-      router.replace('/');
+      router.replace('/photos');
     } else {
       setError('Verification failed');
     }

--- a/apps/web/src/pages/__tests__/2fa-verify.test.tsx
+++ b/apps/web/src/pages/__tests__/2fa-verify.test.tsx
@@ -65,7 +65,7 @@ describe('TwoFAVerifyPage', () => {
 
     await waitFor(() => {
       expect(login).toHaveBeenCalledWith('token123');
-      expect(replace).toHaveBeenCalledWith('/');
+      expect(replace).toHaveBeenCalledWith('/photos');
     });
   });
 });

--- a/docs/web-tool/requirements.md
+++ b/docs/web-tool/requirements.md
@@ -76,6 +76,7 @@ Kernfunktionen:
 - Beim Login ohne gültiges 2FA-Token liefert `/auth/login` einen `challenge_token`.
 - Der Nutzer wird zu `/2fa/verify` geleitet und sendet `POST /auth/2fa/verify` mit `challenge` und Einmalcode.
 - Bei erfolgreicher Verifizierung erhält der Browser wie gewohnt ein JWT (`access_token`).
+- Nach der Verifizierung leitet das Frontend zur Galerie `/photos` weiter.
 
 ## Invite-Flow
 


### PR DESCRIPTION
## Summary
- redirect successful 2FA verification to `/photos`
- update 2FA verification test expectation
- document that 2FA verification leads to gallery

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68a1ae052878832bac32470350c6eb21