### PR TITLE
feat(web): guard customers admin view

### DIFF
--- a/apps/web/src/components/Layout.tsx
+++ b/apps/web/src/components/Layout.tsx
@@ -21,6 +21,7 @@ export default function Layout({ children }: { children: ReactNode }) {
           <div className="nav-links">
             <Link href="/photos">Photos</Link>
             {role === 'ADMIN' && <Link href="/users">Users</Link>}
+            {role === 'ADMIN' && <Link href="/customers">Customers</Link>}
             <Link href="/orders">Orders</Link>
             {role === 'ADMIN' && <Link href="/shares">Shares</Link>}
             {role === 'ADMIN' && <Link href="/locations">Locations</Link>}

--- a/apps/web/src/pages/__tests__/login.test.tsx
+++ b/apps/web/src/pages/__tests__/login.test.tsx
@@ -228,7 +228,7 @@ describe('LoginPage', () => {
     });
   });
 
-  it.each(['/users', '/shares', '/locations'])(
+  it.each(['/users', '/shares', '/locations', '/customers'])(
     'redirects normal users from %s',
     async (path) => {
       store['token'] = 'token123';
@@ -261,6 +261,34 @@ describe('LoginPage', () => {
       });
     },
   );
+
+  it('renders customers link in navigation for admin users', async () => {
+    store['token'] = 'token123';
+    (apiClient.GET as jest.Mock).mockResolvedValueOnce({
+      data: { id: 1, email: 'admin@example.com', role: 'ADMIN' },
+    } as unknown as Awaited<ReturnType<typeof apiClient.GET>>);
+    const push = jest.fn();
+    mockedUseRouter.mockReturnValue({
+      pathname: '/photos',
+      replace: push,
+      push,
+      prefetch: jest.fn(),
+      events: { on: jest.fn(), off: jest.fn() },
+      beforePopState: jest.fn(),
+    });
+
+    render(
+      <AuthProvider>
+        <Layout>
+          <div>content</div>
+        </Layout>
+      </AuthProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Customers')).toBeInTheDocument();
+    });
+  });
 
   it('clears token and redirects to login on logout', () => {
     store['token'] = 'token123';
@@ -340,6 +368,7 @@ describe('LoginPage', () => {
     expect(screen.queryByText('Users')).not.toBeInTheDocument();
     expect(screen.queryByText('Shares')).not.toBeInTheDocument();
     expect(screen.queryByText('Locations')).not.toBeInTheDocument();
+    expect(screen.queryByText('Customers')).not.toBeInTheDocument();
   });
 
   it('does not render navigation links when unauthenticated', () => {

--- a/apps/web/src/pages/_app.tsx
+++ b/apps/web/src/pages/_app.tsx
@@ -24,7 +24,7 @@ export function AuthGuard({ children }: { children: ReactNode }) {
   const { showToast } = useToast();
 
   useEffect(() => {
-    const adminPaths = ['/users', '/shares', '/locations'];
+    const adminPaths = ['/users', '/shares', '/locations', '/customers'];
     const isPublicPath = publicPaths.some((p) =>
       router.pathname.startsWith(p),
     );

--- a/docs/web-tool/requirements.md
+++ b/docs/web-tool/requirements.md
@@ -29,11 +29,11 @@ Kernfunktionen:
 - `AuthContext` verwaltet Loginstatus und Token im Frontend.
 - `AuthGuard` schützt Seiten und leitet nicht authentifizierte Nutzer auf `/login`.
 - Öffentliche Seiten ohne Login: `/login`, `/register`, `/forgot-password`, `/reset`, `/accept`, `/public`, `/2fa/verify`.
-- Admin-Seiten (`Users`, `Shares`, `Locations`) sind nur für Nutzer mit `role === 'ADMIN'` zugänglich und leiten sonst auf `/photos` weiter.
+- Admin-Seiten (`Users`, `Customers`, `Shares`, `Locations`) sind nur für Nutzer mit `role === 'ADMIN'` zugänglich und leiten sonst auf `/photos` weiter.
 - Logout löscht das Token und navigiert zu `/login`.
 - Bei abgelaufener Sitzung (HTTP 401) löscht das Frontend das Token und leitet automatisch auf `/login` weiter.
 - Registrierung neuer Nutzer über Formular (`POST /auth/register`), leitet nach erfolgreicher Registrierung zu `/login`.
-- Navigationsleiste nur für eingeloggte Nutzer mit Links zu `Photos`, `Orders` und `Exports`; Admins sehen zusätzlich `Users`, `Shares` und `Locations`.
+- Navigationsleiste nur für eingeloggte Nutzer mit Links zu `Photos`, `Orders` und `Exports`; Admins sehen zusätzlich `Users`, `Customers`, `Shares` und `Locations`.
 - Branding/Wasserzeichen-Policy je Kunde/Share (Agenturkunden i. d. R. ohne Wasserzeichen).
 
 ## Profilverwaltung
@@ -44,6 +44,7 @@ Kernfunktionen:
 
 ## Kundenverwaltung
 
+- Nur Administratoren haben Zugriff auf die Kundenverwaltung.
 - Kunden paginiert listen (`GET /customers`).
 - Neue Kunden anlegen (`POST /customers`).
 - Kunden bearbeiten (`PATCH /customers/{id}`) und löschen (`DELETE /customers/{id}`).


### PR DESCRIPTION
## Summary
- add Customers navigation link for admins
- protect /customers route via AuthGuard
- document admin-only access to customer management

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68a1b3c96b88832b9d98ef047b7fbe0d