### PR TITLE
feat(web): add map toast feedback

### DIFF
--- a/apps/web/src/components/PhotoMap.tsx
+++ b/apps/web/src/components/PhotoMap.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef } from 'react'
+import { useToast } from './Toast'
 import L from 'leaflet'
 import 'leaflet.markercluster'
 import { apiClient } from '../../lib/api'
@@ -19,6 +20,7 @@ type Props = {
 
 export default function PhotoMap({ shareToken, photoId, adHocSpot }: Props) {
   const containerRef = useRef<HTMLDivElement>(null)
+  const { showToast } = useToast()
 
   useEffect(() => {
     if (!containerRef.current) return
@@ -38,10 +40,15 @@ export default function PhotoMap({ shareToken, photoId, adHocSpot }: Props) {
       marker.addTo(map)
       marker.on('dragend', async (e) => {
         const { lat, lng } = (e.target as L.Marker).getLatLng()
-        await apiClient.PATCH('/photos/{id}', {
-          params: { path: { id: photoId } },
-          body: { ad_hoc_spot: { lat, lon: lng } },
-        })
+        try {
+          await apiClient.PATCH('/photos/{id}', {
+            params: { path: { id: photoId } },
+            body: { ad_hoc_spot: { lat, lon: lng } },
+          })
+          showToast('success', 'Location updated')
+        } catch {
+          showToast('error', 'Update failed')
+        }
       })
       return () => {
         map.remove()
@@ -53,47 +60,57 @@ export default function PhotoMap({ shareToken, photoId, adHocSpot }: Props) {
     map.addLayer(cluster)
 
     const fetchPhotos = async () => {
-      const bounds = map.getBounds()
-      const bbox = [
-        bounds.getSouth(),
-        bounds.getWest(),
-        bounds.getNorth(),
-        bounds.getEast(),
-      ].join(',')
-      const { data } = shareToken
-        ? await apiClient.GET('/public/shares/{token}/photos', {
-            params: { path: { token: shareToken }, query: { bbox } },
-          })
-        : await apiClient.GET('/photos', {
-            params: { query: { bbox } },
-          })
-      cluster.clearLayers()
-      data?.items?.forEach((p: Photo) => {
-        if (p.ad_hoc_spot) {
-          const marker = L.marker(
-            [p.ad_hoc_spot.lat, p.ad_hoc_spot.lon],
-            shareToken
-              ? {}
-              : {
-                  draggable: true,
-                  icon: L.divIcon({
-                    className: '',
-                    html: '<div data-testid="marker"></div>',
-                  }),
-                },
-          )
-          if (!shareToken) {
-            marker.on('dragend', async (e) => {
-              const { lat, lng } = (e.target as L.Marker).getLatLng()
-              await apiClient.PATCH('/photos/{id}', {
-                params: { path: { id: p.id } },
-                body: { ad_hoc_spot: { lat, lon: lng } },
-              })
+      try {
+        const bounds = map.getBounds()
+        const bbox = [
+          bounds.getSouth(),
+          bounds.getWest(),
+          bounds.getNorth(),
+          bounds.getEast(),
+        ].join(',')
+        const { data, error } = shareToken
+          ? await apiClient.GET('/public/shares/{token}/photos', {
+              params: { path: { token: shareToken }, query: { bbox } },
             })
+          : await apiClient.GET('/photos', {
+              params: { query: { bbox } },
+            })
+        if (error) throw error
+        cluster.clearLayers()
+        data?.items?.forEach((p: Photo) => {
+          if (p.ad_hoc_spot) {
+            const marker = L.marker(
+              [p.ad_hoc_spot.lat, p.ad_hoc_spot.lon],
+              shareToken
+                ? {}
+                : {
+                    draggable: true,
+                    icon: L.divIcon({
+                      className: '',
+                      html: '<div data-testid="marker"></div>',
+                    }),
+                  },
+            )
+            if (!shareToken) {
+              marker.on('dragend', async (e) => {
+                const { lat, lng } = (e.target as L.Marker).getLatLng()
+                try {
+                  await apiClient.PATCH('/photos/{id}', {
+                    params: { path: { id: p.id } },
+                    body: { ad_hoc_spot: { lat, lon: lng } },
+                  })
+                  showToast('success', 'Location updated')
+                } catch {
+                  showToast('error', 'Update failed')
+                }
+              })
+            }
+            cluster.addLayer(marker)
           }
-          cluster.addLayer(marker)
-        }
-      })
+        })
+      } catch {
+        showToast('error', 'Failed to load photos')
+      }
     }
 
     fetchPhotos()
@@ -103,7 +120,7 @@ export default function PhotoMap({ shareToken, photoId, adHocSpot }: Props) {
       map.off('moveend', fetchPhotos)
       map.remove()
     }
-  }, [shareToken, photoId, adHocSpot])
+  }, [shareToken, photoId, adHocSpot, showToast])
 
   return <div ref={containerRef} style={{ height: '400px' }} data-testid="photo-map" />
 }

--- a/apps/web/src/pages/__tests__/photos.test.tsx
+++ b/apps/web/src/pages/__tests__/photos.test.tsx
@@ -686,5 +686,8 @@ describe('PhotoDetailPage', () => {
         }),
       ),
     )
+    await waitFor(() =>
+      expect(screen.getByRole('alert')).toHaveTextContent('Location updated'),
+    )
   })
 })

--- a/apps/web/src/pages/__tests__/public-share.test.tsx
+++ b/apps/web/src/pages/__tests__/public-share.test.tsx
@@ -314,5 +314,24 @@ describe('PublicSharePage', () => {
       expect(screen.getAllByTestId('marker').length).toBeGreaterThan(0)
     })
   })
+
+  it('shows toast on map fetch error', async () => {
+    ;(apiClient.GET as jest.Mock)
+      .mockResolvedValueOnce({ data: { download_allowed: true } })
+      .mockResolvedValueOnce({ data: { items: [] } })
+      .mockResolvedValueOnce({ error: {} })
+
+    renderPage()
+
+    fireEvent.click(screen.getByText('Map'))
+
+    await waitFor(() => {
+      expect(screen.getByTestId('photo-map')).toBeInTheDocument()
+    })
+
+    await waitFor(() =>
+      expect(screen.getByRole('alert')).toHaveTextContent('Failed to load photos'),
+    )
+  })
 })
 

--- a/docs/web-tool/requirements.md
+++ b/docs/web-tool/requirements.md
@@ -11,7 +11,8 @@ Kernfunktionen:
 - Galerie mit schneller Filterung (Plakatierer, Woche, Standort, Modus, Qualität, Auftrag, Kunde, Zeitraum, Status) sowie spezifischen Parametern `from`, `to`, `orderId`, `status`, `siteId`, `calendarWeek`, `qualityFlag`, `customerId`. Weitere Seiten werden beim Scrollen automatisch über einen `IntersectionObserver` nachgeladen (`page`/`limit`-basiertes Infinite Scroll).
 - Kartenansicht mit Leaflet, lädt `/photos?bbox=` abhängig vom Kartenausschnitt,
   clustert Marker und erlaubt Standortkorrektur per Drag-and-Drop
-  (`PATCH /photos/{id}` aktualisiert die Koordinaten).
+  (`PATCH /photos/{id}` aktualisiert die Koordinaten) und gibt
+  nach Standortänderungen über Toasts Rückmeldung (Erfolg/Fehler).
 - Leaflet-Styles (`leaflet/dist/leaflet.css`, `leaflet.markercluster/dist/MarkerCluster.css`) müssen eingebunden werden.
 - Bulk-Operationen: Multi-Select, Zuweisen (`POST /photos/batch/assign`), Ausblenden (`POST /photos/batch/hide`), Curate-Flag (`POST /photos/batch/curate`), Re-Matching (`POST /photos/batch/rematch`), Export ausgewählter Fotos als ZIP/Excel/PDF (`POST /exports/zip`, `POST /exports/excel`, `POST /exports/pdf`).
 - Mehrfachauswahl im Grid/Table mit Auftragszuweisung via `POST /photos/batch/assign`; weitere Batch-Aktionen über `POST /photos/batch/hide`, `POST /photos/batch/curate` und `POST /photos/batch/rematch`.


### PR DESCRIPTION
## Summary
- show toast feedback for map drag updates and failed photo fetches
- test toast behaviour for map drag and public share map errors
- document toast feedback after map location changes

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68a1b5516324832bb568ca0fe1d2dbd6