### PR TITLE
feat: rely on toast notifications for reset page errors

### DIFF
--- a/apps/web/src/pages/__tests__/reset.test.tsx
+++ b/apps/web/src/pages/__tests__/reset.test.tsx
@@ -45,13 +45,12 @@ describe('ResetPage', () => {
         body: { token: 'tok1', password: 'pw' },
       });
       expect(replace).toHaveBeenCalledWith('/login');
-      expect(screen.getByRole('alert')).toHaveTextContent(
-        'Password reset. You can now log in.',
-      );
     });
+    const toast = await screen.findByRole('alert');
+    expect(toast).toHaveTextContent('Password reset. You can now log in.');
   });
 
-  it('shows error on failure', async () => {
+  it('shows error toast on failure', async () => {
     (apiClient.POST as jest.Mock).mockResolvedValue({ error: {} });
 
     render(
@@ -65,12 +64,11 @@ describe('ResetPage', () => {
     });
     fireEvent.click(screen.getByText('Reset Password'));
 
-    await waitFor(() => {
-      expect(screen.getByRole('alert')).toHaveTextContent('Reset failed');
-    });
+    const toast = await screen.findByRole('alert');
+    expect(toast).toHaveTextContent('Reset failed');
   });
 
-  it('redirects on invalid token', async () => {
+  it('redirects on invalid token and shows toast', async () => {
     (apiClient.POST as jest.Mock).mockResolvedValue({ error: { status: 404 } });
 
     render(
@@ -85,8 +83,7 @@ describe('ResetPage', () => {
     fireEvent.click(screen.getByText('Reset Password'));
 
     await waitFor(() => expect(replace).toHaveBeenCalledWith('/login'));
-    await waitFor(() =>
-      expect(screen.getByRole('alert')).toHaveTextContent('Invalid token'),
-    );
+    const toast = await screen.findByRole('alert');
+    expect(toast).toHaveTextContent('Invalid token');
   });
 });

--- a/apps/web/src/pages/reset/[token].tsx
+++ b/apps/web/src/pages/reset/[token].tsx
@@ -7,22 +7,20 @@ export default function ResetPage() {
   const router = useRouter();
   const { token } = router.query;
   const [password, setPassword] = useState('');
-  const [error, setError] = useState<string | null>(null);
   const { showToast } = useToast();
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    setError(null);
     if (!token || Array.isArray(token)) return;
-    const { error: err } = await apiClient.POST('/auth/reset', {
+    const { error } = await apiClient.POST('/auth/reset', {
       body: { token, password },
     });
-    if (err) {
-      if (err.status === 404) {
+    if (error) {
+      if (error.status === 404) {
         showToast('error', 'Invalid token');
         router.replace('/login');
       } else {
-        setError('Reset failed');
+        showToast('error', 'Reset failed');
       }
     } else {
       showToast('success', 'Password reset. You can now log in.');
@@ -39,11 +37,6 @@ export default function ResetPage() {
         onChange={(e) => setPassword(e.target.value)}
       />
       <button type="submit">Reset Password</button>
-      {error && (
-        <div role="alert" style={{ color: 'red' }}>
-          {error}
-        </div>
-      )}
     </form>
   );
 }

--- a/docs/web-tool/requirements.md
+++ b/docs/web-tool/requirements.md
@@ -114,3 +114,4 @@ UX/Leistung:
 - Zentrale Toast-Komponente f\u00fcr Erfolg- und Fehlermeldungen.
 - `AuthGuard` informiert \u00fcber fehlende Berechtigungen oder nicht eingeloggte Nutzer.
 - Seiten wie `Register`, `Forgot Password`, `Accept`, `Profile`, `Photos`, `Orders` (inkl. Detailseiten), `Shares`, `Users`, `Customers` und `Locations` zeigen Ergebnis von API-Aktionen über Toasts an (z. B. Einladungen oder Rollenänderungen, Kundenanlage/-aktualisierung, Standort-Updates).
+- Die Reset-Seite nutzt ausschließlich Toasts für Fehlermeldungen.


### PR DESCRIPTION
## Summary
- show reset errors via toast instead of inline state
- expect toast notifications in reset page tests
- document reset page toast-only error handling

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68a24caa41fc832b92f6806a065429cf